### PR TITLE
Enable all possible leon3 bare-metal tests

### DIFF
--- a/utils/grlib/software/leon3/leon3_test.c
+++ b/utils/grlib/software/leon3/leon3_test.c
@@ -34,17 +34,23 @@ leon3_test(int domp, int *irqmp, int mtest)
     /* report_test(TEST_REG); */
     /* if (regtest()) report_fail(FAIL_REG); */
 
-    /* report_test(TEST_MUL); */
-    /* multest(); */
+    report_test(TEST_MUL);
+    multest();
 
-    /* report_test(TEST_DIV); */
-    /* divtest(); */
+    report_test(TEST_DIV);
+    divtest();
 
     /* //report_test(TEST_FPU); */
     /* //fputest(); */
 
-    /* report_test(TEST_FILL_W); */
-    /* cache_fill(4, ncpu, WORD); */
+    if (!pid) data_structures_setup();
+
+    report_test(TEST_FILL_B);
+    cache_fill(4, ncpu, BYTE);
+    report_test(TEST_FILL_HW);
+    cache_fill(4, ncpu, HALFWORD);
+    report_test(TEST_FILL_W);
+    cache_fill(4, ncpu, WORD);
     
     report_test(TEST_SHARING);
     false_sharing(20, ncpu);
@@ -55,11 +61,11 @@ leon3_test(int domp, int *irqmp, int mtest)
     report_test(TEST_LOCK);
     test_lock(100, ncpu);
 
-    /* report_test(TEST_MESI); */
-    /* mesi_test(ncpu, 1); */
+    report_test(TEST_MESI);
+    mesi_test(ncpu, 1);
 
-    /* report_test(TEST_RAND_RW); */
-    /* rand_rw(200, ncpu); */
+    report_test(TEST_RAND_RW);
+    rand_rw(200, ncpu);
     
     /* End of TESTS */
     

--- a/utils/grlib/software/leon3/leon3_test.c
+++ b/utils/grlib/software/leon3/leon3_test.c
@@ -36,9 +36,11 @@ leon3_test(int domp, int *irqmp, int mtest)
 
     report_test(TEST_MUL);
     multest();
+    if (!pid) printf("Finished multest.\n");
 
     report_test(TEST_DIV);
     divtest();
+    if (!pid) printf("Finished divtest.\n");
 
     /* //report_test(TEST_FPU); */
     /* //fputest(); */
@@ -47,10 +49,13 @@ leon3_test(int domp, int *irqmp, int mtest)
 
     report_test(TEST_FILL_B);
     cache_fill(4, ncpu, BYTE);
+    if (!pid) printf("Finished cache_fill with BYTE granularity.\n");
     report_test(TEST_FILL_HW);
     cache_fill(4, ncpu, HALFWORD);
+    if (!pid) printf("Finished cache_fill with HALFWORD granularity.\n");
     report_test(TEST_FILL_W);
     cache_fill(4, ncpu, WORD);
+    if (!pid) printf("Finished cache_fill with WORD granularity.\n");
     
     report_test(TEST_SHARING);
     false_sharing(20, ncpu);
@@ -60,12 +65,15 @@ leon3_test(int domp, int *irqmp, int mtest)
 
     report_test(TEST_LOCK);
     test_lock(100, ncpu);
+    if (!pid) printf("Finished test_lock.\n");
 
     report_test(TEST_MESI);
     mesi_test(ncpu, 1);
+    if (!pid) printf("Finished mesi_test.\n");
 
     report_test(TEST_RAND_RW);
     rand_rw(200, ncpu);
+    if (!pid) printf("Finished rand_rw.\n");
     
     /* End of TESTS */
     

--- a/utils/grlib/software/leon3/leon3_test.c
+++ b/utils/grlib/software/leon3/leon3_test.c
@@ -48,13 +48,13 @@ leon3_test(int domp, int *irqmp, int mtest)
     if (!pid) data_structures_setup();
 
     report_test(TEST_FILL_B);
-    cache_fill(4, ncpu, BYTE);
+    cache_fill(L2_WAYS, ncpu, BYTE);
     if (!pid) printf("Finished cache_fill with BYTE granularity.\n");
     report_test(TEST_FILL_HW);
-    cache_fill(4, ncpu, HALFWORD);
+    cache_fill(L2_WAYS, ncpu, HALFWORD);
     if (!pid) printf("Finished cache_fill with HALFWORD granularity.\n");
     report_test(TEST_FILL_W);
-    cache_fill(4, ncpu, WORD);
+    cache_fill(L2_WAYS, ncpu, WORD);
     if (!pid) printf("Finished cache_fill with WORD granularity.\n");
     
     report_test(TEST_SHARING);


### PR DESCRIPTION
The following multicore baremetal tests from GrLib were enabled and tested during the development of Spandex LLC at UIUC using a quad-core leon3 configuration. The enabled tests were also verified on an original ESP quad-core system. When calling **base_test()** from **systest.c** in the design folder, CPU 0 should print a report of all successfully executed tasks by each CPU.