### PR TITLE
Add support for Vivado HLS generated IPs and float interfaces

### DIFF
--- a/accelerators/vivado_hls/adder/inc/espacc.h
+++ b/accelerators/vivado_hls/adder/inc/espacc.h
@@ -25,6 +25,12 @@
 typedef ap_fixed<DATA_BITWIDTH-FRAC_BITS,FRAC_BITS> word_t;
 #elif (IS_TYPE_UINT == 1)
 typedef ap_uint<DATA_BITWIDTH> word_t;
+#elif (IS_TYPE_FLOAT == 1)
+#if (DATA_BITWIDTH == 32)
+typedef float word_t;
+#else
+#error "Floating point word bitwidth not supported. Only 32 is supported."
+#endif
 #else // (IS_TYPE_INT == 1)
 typedef ap_int<DATA_BITWIDTH> word_t;
 #endif

--- a/accelerators/vivado_hls/adder/inc/espacc_config.h
+++ b/accelerators/vivado_hls/adder/inc/espacc_config.h
@@ -9,6 +9,7 @@
 #define FRAC_BITS 0
 #define IS_TYPE_UINT 0
 #define IS_TYPE_INT 1
+#define IS_TYPE_FLOAT 0
 
 // In/out arrays
 

--- a/accelerators/vivado_hls/adder/syn/custom.tcl
+++ b/accelerators/vivado_hls/adder/syn/custom.tcl
@@ -5,6 +5,12 @@
 
 set dma_width {32 64}
 set word_widths {8 16 32}
+# specify if the input or the output of the accelerator are float
+# set dataype "" if input and output are NOT float
+# set dataype "fl" if both input and output are float
+# set dataype "flin" if only the input is float
+# set dataype "flout" if only the output is float
+set datatype ""
 
 # Clock period
 

--- a/accelerators/vivado_hls/adder/syn/custom.tcl
+++ b/accelerators/vivado_hls/adder/syn/custom.tcl
@@ -7,9 +7,9 @@ set dma_width {32 64}
 set word_widths {8 16 32}
 # specify if the input or the output of the accelerator are float
 # set dataype "" if input and output are NOT float
-# set dataype "fl" if both input and output are float
-# set dataype "flin" if only the input is float
-# set dataype "flout" if only the output is float
+# set dataype "fl32" if both input and output are float
+# set dataype "fl32in" if only the input is float
+# set dataype "fl32out" if only the output is float
 set datatype ""
 
 # Clock period

--- a/accelerators/vivado_hls/common/syn/Makefile
+++ b/accelerators/vivado_hls/common/syn/Makefile
@@ -20,8 +20,10 @@ endif
 		PRJ_NAME=$$prj; \
 		mkdir -p $(RTL_OUT)/$$PRJ_NAME; \
 		cp $$PRJ_NAME/$(TARGET_NAME)_acc/impl/ip/hdl/verilog/* $(RTL_OUT)/$$PRJ_NAME; \
-		if [ -e $$PRJ_NAME/$(TARGET_NAME)_acc/impl/ip/hdl/ip/* ]; then \
-			cp $$PRJ_NAME/$(TARGET_NAME)_acc/impl/ip/hdl/ip/* $(RTL_OUT)/$$PRJ_NAME; \
+		if [ -e $$PRJ_NAME/$(TARGET_NAME)_acc/impl/ip/hdl/ip ]; then \
+			if [ -z $(ls -A $$PRJ_NAME/$(TARGET_NAME)_acc/impl/ip/hdl/ip) ]; then \
+				cp $$PRJ_NAME/$(TARGET_NAME)_acc/impl/ip/hdl/ip/* $(RTL_OUT)/$$PRJ_NAME; \
+			fi; \
 		fi; \
 		if [ -e $$PRJ_NAME/$(TARGET_NAME)_acc/impl/ip/tmp.srcs/sources_1/ip ]; then \
 			for dir in $$(ls $$PRJ_NAME/$(TARGET_NAME)_acc/impl/ip/tmp.srcs/sources_1/ip); do \

--- a/accelerators/vivado_hls/common/syn/common.tcl
+++ b/accelerators/vivado_hls/common/syn/common.tcl
@@ -24,7 +24,11 @@ foreach dma $dma_width {
 	set unroll_factor [expr $dma / $width]
 
 	# Create project
-	open_project "${ACCELERATOR}_dma${dma}_w${width}"
+	if {$datatype eq ""} {
+	    open_project "${ACCELERATOR}_dma${dma}_w${width}"
+	} else {
+	    open_project "${ACCELERATOR}_dma${dma}_w${width}_${datatype}"
+	}
 
 	set_top "top"
 
@@ -51,7 +55,11 @@ foreach dma $dma_width {
 	}
 
 	# Config HLS
-	config_rtl -prefix "${ACCELERATOR}_dma${dma}_w${width}_" 
+	if {$datatype eq ""} {
+	    config_rtl -prefix "${ACCELERATOR}_dma${dma}_w${width}_"
+	} else {
+	    config_rtl -prefix "${ACCELERATOR}_dma${dma}_w${width}_${datatype}_"
+	}
 	config_compile -no_signed_zeros=0 -unsafe_math_optimizations=0
 	config_schedule -effort medium -relax_ii_for_timing=0 -verbose=0
 	config_bind -effort medium

--- a/soft/leon3/drivers/adder/barec/adder.c
+++ b/soft/leon3/drivers/adder/barec/adder.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <esp_accelerator.h>
 #include <esp_probe.h>
+#include <fixed_point.h>
 
 /////////////////////////////////
 // TODO include accelerators configuration header
@@ -29,6 +30,7 @@
 
 #define DATA_BITWIDTH 32
 typedef int32_t word_t;
+// typedef float word_t; // use this if the accelerator is floating point
 /////////////////////////////////
 
 // Specify accelerator type

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -824,6 +824,8 @@ VLOG_RTL_SRCS  += $(shell (find $(ESP_ROOT)/tech/$(TECHLIB) -name "*.v" ))
 
 SVLOG_RTL_SRCS  = $(shell (find $(ESP_ROOT)/rtl/src -name "*.sv" ))
 
+IP_XCI_SRCS  = $(shell (find $(ESP_ROOT)/tech/$(TECHLIB) -name "*.xci" ))
+
 VHDL_SIM_PKGS  = $(shell (find $(ESP_ROOT)/sim/include -name "*.vhd" ))
 VHDL_SIM_SRCS  = $(shell (find $(ESP_ROOT)/sim/src -name "*.vhd" ))
 VLOG_SIM_SRCS  = $(shell (find $(ESP_ROOT)/sim/src -name "*.v" ))
@@ -888,7 +890,7 @@ check_all_rtl_srcs-distclean:
 
 $(ESP_ROOT)/.cache/modelsim/xilinx_lib:
 	$(QUIET_MKDIR)mkdir -p $@
-	@echo "compile_simlib -directory xilinx_lib -simulator modelsim -library unisim -no_ip_compile" > $@/simlib.tcl; \
+	@echo "compile_simlib -directory xilinx_lib -simulator modelsim -library all" > $@/simlib.tcl; \
 	cd $(ESP_ROOT)/.cache/modelsim; \
 	if ! vivado $(VIVADO_BATCH_OPT) -source xilinx_lib/simlib.tcl; then \
 		echo "$(SPACES)ERROR: Xilinx library compilation failed!"; rm -rf xilinx_lib modelsim.ini; exit 1; \
@@ -912,7 +914,7 @@ modelsim/modelsim.ini: $(ESP_ROOT)/.cache/modelsim/xilinx_lib
 
 $(ESP_ROOT)/.cache/xcelium/xilinx_lib:
 	$(QUIET_MKDIR)mkdir -p $@
-	@echo "compile_simlib -directory xilinx_lib -simulator xcelium -library unisim -no_ip_compile" > $@/simlib.tcl; \
+	@echo "compile_simlib -directory xilinx_lib -simulator xcelium -library all" > $@/simlib.tcl; \
 	cd $(ESP_ROOT)/.cache/xcelium; \
 	if ! vivado $(VIVADO_BATCH_OPT) -source xilinx_lib/simlib.tcl; then \
 		echo "$(SPACES)ERROR: Xilinx library compilation failed!"; rm -rf xilinx_lib cds.lib; exit 1; \
@@ -928,7 +930,7 @@ xcelium/hdl.var: xcelium/cds.lib
 
 $(ESP_ROOT)/.cache/incisive/xilinx_lib:
 	$(QUIET_MKDIR)mkdir -p $@
-	@echo "compile_simlib -directory xilinx_lib -simulator ies -library unisim -no_ip_compile" > $@/simlib.tcl; \
+	@echo "compile_simlib -directory xilinx_lib -simulator ies -library all" > $@/simlib.tcl; \
 	cd $(ESP_ROOT)/.cache/incisive; \
 	if ! vivado $(VIVADO_BATCH_OPT) -source xilinx_lib/simlib.tcl; then \
 		echo "$(SPACES)ERROR: Xilinx library compilation failed!"; rm -rf xilinx_lib cds.lib; exit 1; \
@@ -1406,6 +1408,12 @@ endif
 	@echo "source ./srcs.tcl" >> $@
 ifneq ("$(PROTOBOARD)","")
 	@echo "set_property board_part $(PROTOBOARD) [current_project]"  >> $@
+endif
+ifneq ($(IP_XCI_SRCS),)
+	@for rtl in $(IP_XCI_SRCS); do \
+		echo "import_ip -files $$rtl" >> $@; \
+	done;
+	@echo "upgrade_ip [get_ips -all]" >> $@
 endif
 	@if test -r $(ESP_ROOT)/constraints/$(BOARD)/mig.xci; then \
 		echo $(SPACES)"INFO including MIG IP"; \

--- a/utils/scripts/templates/drivers/barec/accelerator.c
+++ b/utils/scripts/templates/drivers/barec/accelerator.c
@@ -8,6 +8,7 @@
 
 #include <esp_accelerator.h>
 #include <esp_probe.h>
+#include <fixed_point.h>
 
 typedef /* <<--token-type-->> */ token_t;
 

--- a/utils/scripts/templates/hls4ml/inc/espacc.h
+++ b/utils/scripts/templates/hls4ml/inc/espacc.h
@@ -27,6 +27,12 @@
 typedef ap_fixed<DATA_BITWIDTH,DATA_BITWIDTH-FRAC_BITS> word_t;
 #elif (IS_TYPE_UINT == 1)
 typedef ap_uint<DATA_BITWIDTH> word_t;
+#elif (IS_TYPE_FLOAT == 1)
+#if (DATA_BITWIDTH == 32)
+typedef float word_t;
+#else
+#error "Floating point word bitwidth not supported. Only 32 is supported."
+#endif
 #else // (IS_TYPE_INT == 1)
 typedef ap_int<DATA_BITWIDTH> word_t;
 #endif

--- a/utils/scripts/templates/hls4ml/inc/espacc_config.h
+++ b/utils/scripts/templates/hls4ml/inc/espacc_config.h
@@ -9,6 +9,7 @@
 #define FRAC_BITS /* <<--frac-bits-->> */
 #define IS_TYPE_UINT 0
 #define IS_TYPE_INT 0
+#define IS_TYPE_FLOAT 0
 
 // In/out arrays
 

--- a/utils/scripts/templates/hls4ml/syn/custom.tcl
+++ b/utils/scripts/templates/hls4ml/syn/custom.tcl
@@ -5,6 +5,12 @@
 
 set dma_width {<<--dma-width-->>}
 set word_widths {<<--data-widths-->>}
+# specify if the input or the output of the accelerator are float
+# set dataype "" if input and output are NOT float
+# set dataype "fl" if both input and output are float
+# set dataype "flin" if only the input is float
+# set dataype "flout" if only the output is float
+set datatype ""
 
 # Clock period
 

--- a/utils/scripts/templates/hls4ml/syn/custom.tcl
+++ b/utils/scripts/templates/hls4ml/syn/custom.tcl
@@ -7,9 +7,9 @@ set dma_width {<<--dma-width-->>}
 set word_widths {<<--data-widths-->>}
 # specify if the input or the output of the accelerator are float
 # set dataype "" if input and output are NOT float
-# set dataype "fl" if both input and output are float
-# set dataype "flin" if only the input is float
-# set dataype "flout" if only the output is float
+# set dataype "fl32" if both input and output are float
+# set dataype "fl32in" if only the input is float
+# set dataype "fl32out" if only the output is float
 set datatype ""
 
 # Clock period
@@ -20,6 +20,9 @@ if {[lsearch $fpga_techs $TECH] >= 0} {
     }
     if {$TECH eq "zynq7000"} {
 	set clock_period 10
+    }
+    if {$TECH eq "virtexu"} {
+	set clock_period 8
     }
     if {$TECH eq "virtexup"} {
 	set clock_period 10

--- a/utils/scripts/templates/vivado_hls/inc/espacc.h
+++ b/utils/scripts/templates/vivado_hls/inc/espacc.h
@@ -28,6 +28,12 @@
 typedef ap_fixed<DATA_BITWIDTH,DATA_BITWIDTH-FRAC_BITS> word_t;
 #elif (IS_TYPE_UINT == 1)
 typedef ap_uint<DATA_BITWIDTH> word_t;
+#elif (IS_TYPE_FLOAT == 1)
+#if (DATA_BITWIDTH == 32)
+typedef float word_t;
+#else
+#error "Floating point word bitwidth not supported. Only 32 is supported."
+#endif
 #else // (IS_TYPE_INT == 1)
 typedef ap_int<DATA_BITWIDTH> word_t;
 #endif

--- a/utils/scripts/templates/vivado_hls/inc/espacc_config.h
+++ b/utils/scripts/templates/vivado_hls/inc/espacc_config.h
@@ -9,6 +9,7 @@
 #define FRAC_BITS 0
 #define IS_TYPE_UINT 0
 #define IS_TYPE_INT 1
+#define IS_TYPE_FLOAT 0
 
 // In/out arrays
 

--- a/utils/scripts/templates/vivado_hls/syn/custom.tcl
+++ b/utils/scripts/templates/vivado_hls/syn/custom.tcl
@@ -5,6 +5,12 @@
 
 set dma_width {<<--dma-width-->>}
 set word_widths {<<--data-widths-->>}
+# specify if the input or the output of the accelerator are float
+# set dataype "" if input and output are NOT float
+# set dataype "fl" if both input and output are float
+# set dataype "flin" if only the input is float
+# set dataype "flout" if only the output is float
+set datatype ""
 
 # Clock period
 

--- a/utils/scripts/templates/vivado_hls/syn/custom.tcl
+++ b/utils/scripts/templates/vivado_hls/syn/custom.tcl
@@ -7,9 +7,9 @@ set dma_width {<<--dma-width-->>}
 set word_widths {<<--data-widths-->>}
 # specify if the input or the output of the accelerator are float
 # set dataype "" if input and output are NOT float
-# set dataype "fl" if both input and output are float
-# set dataype "flin" if only the input is float
-# set dataype "flout" if only the output is float
+# set dataype "fl32" if both input and output are float
+# set dataype "fl32in" if only the input is float
+# set dataype "fl32out" if only the output is float
 set datatype ""
 
 # Clock period

--- a/utils/sldgen/sld_generate.py
+++ b/utils/sldgen/sld_generate.py
@@ -54,6 +54,7 @@ class Implementation():
   def __init__(self):
     self.name = ""
     self.dma_width = 0
+    self.datatype = ""
 
   def __str__(self):
     return self.name
@@ -308,7 +309,7 @@ def write_axi_acc_port_map(f, acc, dma_width):
   f.write("    );\n")
 
 
-def write_acc_interface(f, acc, dma_width, rst, is_vivadohls_if, is_catapulthls_cxx_if, is_catapulthls_sysc_if):
+def write_acc_interface(f, acc, dma_width, datatype, rst, is_vivadohls_if, is_catapulthls_cxx_if, is_catapulthls_sysc_if):
 
   if is_catapulthls_cxx_if:
     conf_info_size = 0
@@ -386,12 +387,22 @@ def write_acc_interface(f, acc, dma_width, rst, is_vivadohls_if, is_catapulthls_
     f.write("      ap_done                    : out std_ulogic;\n")
     f.write("      ap_idle                    : out std_ulogic;\n")
     f.write("      ap_ready                   : out std_ulogic;\n")
-    f.write("      out_word_V_din             : out std_logic_vector (" + str(dma_width - 1) + " downto 0);\n")
-    f.write("      out_word_V_full_n          : in  std_logic;\n")
-    f.write("      out_word_V_write           : out std_logic;\n")
-    f.write("      in1_word_V_dout            : in  std_logic_vector (" + str(dma_width - 1) + " downto 0);\n")
-    f.write("      in1_word_V_empty_n         : in  std_logic;\n")
-    f.write("      in1_word_V_read            : out std_logic;\n")
+    if datatype == 'float' or  datatype == 'float_out':
+      f.write("      out_word_din             : out std_logic_vector (" + str(dma_width - 1) + " downto 0);\n")
+      f.write("      out_word_full_n          : in  std_logic;\n")
+      f.write("      out_word_write           : out std_logic;\n")
+    else:
+      f.write("      out_word_V_din             : out std_logic_vector (" + str(dma_width - 1) + " downto 0);\n")
+      f.write("      out_word_V_full_n          : in  std_logic;\n")
+      f.write("      out_word_V_write           : out std_logic;\n")
+    if datatype == 'float' or  datatype == 'float_in':
+      f.write("      in1_word_dout            : in  std_logic_vector (" + str(dma_width - 1) + " downto 0);\n")
+      f.write("      in1_word_empty_n         : in  std_logic;\n")
+      f.write("      in1_word_read            : out std_logic;\n")
+    else:
+      f.write("      in1_word_V_dout            : in  std_logic_vector (" + str(dma_width - 1) + " downto 0);\n")
+      f.write("      in1_word_V_empty_n         : in  std_logic;\n")
+      f.write("      in1_word_V_read            : out std_logic;\n")
     f.write("      load_ctrl                  : out std_logic_vector (" + str(95) + " downto 0);\n")
     f.write("      load_ctrl_ap_ack           : in  std_logic;\n")
     f.write("      load_ctrl_ap_vld           : out std_logic;\n")
@@ -446,7 +457,7 @@ def write_ap_acc_signals(f):
   f.write("signal dma_write_ctrl_data : std_logic_vector(95 downto 0);\n")
   f.write("\n")
 
-def write_acc_port_map(f, acc, dma_width, rst, is_noc_interface, is_vivadohls_if, is_catapulthls_cxx_if, is_catapulthls_sysc_if):
+def write_acc_port_map(f, acc, dma_width, datatype, rst, is_noc_interface, is_vivadohls_if, is_catapulthls_cxx_if, is_catapulthls_sysc_if):
 
   if is_vivadohls_if:
     f.write("    port map(\n")
@@ -468,12 +479,20 @@ def write_acc_port_map(f, acc, dma_width, rst, is_noc_interface, is_vivadohls_if
     f.write("      store_ctrl_ap_vld          => dma_write_ctrl_valid,\n")
     f.write("      store_ctrl_ap_ack          => dma_write_ctrl_ready,\n")
     f.write("      store_ctrl                 => dma_write_ctrl_data,\n")
-    f.write("      in1_word_V_empty_n         => dma_read_chnl_valid,\n")
-    f.write("      in1_word_V_read            => dma_read_chnl_ready,\n")
-    f.write("      in1_word_V_dout            => dma_read_chnl_data,\n")
-    f.write("      out_word_V_write           => dma_write_chnl_valid,\n")
-    f.write("      out_word_V_full_n          => dma_write_chnl_ready,\n")
-    f.write("      out_word_V_din             => dma_write_chnl_data,\n")
+    if datatype == 'float':
+      f.write("      in1_word_empty_n         => dma_read_chnl_valid,\n")
+      f.write("      in1_word_read            => dma_read_chnl_ready,\n")
+      f.write("      in1_word_dout            => dma_read_chnl_data,\n")
+      f.write("      out_word_write           => dma_write_chnl_valid,\n")
+      f.write("      out_word_full_n          => dma_write_chnl_ready,\n")
+      f.write("      out_word_din             => dma_write_chnl_data,\n")
+    else:
+      f.write("      in1_word_V_empty_n         => dma_read_chnl_valid,\n")
+      f.write("      in1_word_V_read            => dma_read_chnl_ready,\n")
+      f.write("      in1_word_V_dout            => dma_read_chnl_data,\n")
+      f.write("      out_word_V_write           => dma_write_chnl_valid,\n")
+      f.write("      out_word_V_full_n          => dma_write_chnl_ready,\n")
+      f.write("      out_word_V_din             => dma_write_chnl_data,\n")
     f.write("      ap_done                    => ap_done,\n")
     f.write("      ap_idle                    => ap_idle,\n")
     f.write("      ap_ready                   => ap_ready\n")
@@ -912,19 +931,19 @@ def gen_tech_dep(accelerator_list, cache_list, dma_width, template_dir, out_dir)
           if acc.hls_tool == 'stratus_hls':
             f.write("  component " + acc.name + "_" + impl.name + "\n")
             f.write("    port (\n")
-            write_acc_interface(f, acc, dma_width, "rst", False, False, False)
+            write_acc_interface(f, acc, dma_width, impl.datatype, "rst", False, False, False)
           elif acc.hls_tool == 'catapult_hls_cxx':
             f.write("  component " + acc.name + "_" + impl.name + "\n")
             f.write("    port (\n")
-            write_acc_interface(f, acc, dma_width, "rst", False, True, False)
+            write_acc_interface(f, acc, dma_width, impl.datatype, "rst", False, True, False)
           elif acc.hls_tool == 'catapult_hls_sysc':
             f.write("  component " + acc.name + "_" + impl.name + "\n")
             f.write("    port (\n")
-            write_acc_interface(f, acc, dma_width, "rst", False, False, True)
+            write_acc_interface(f, acc, dma_width, impl.datatype, "rst", False, False, True)
           else:
             f.write("  component " + acc.name + "_" + impl.name + "_top\n")
             f.write("    port (\n")
-            write_acc_interface(f, acc, dma_width, "ap_rst", True, False, False)
+            write_acc_interface(f, acc, dma_width, impl.datatype, "ap_rst", True, False, False)
           f.write("    );\n")
           f.write("  end component;\n\n")
           f.write("\n")
@@ -966,7 +985,7 @@ def gen_tech_indep(accelerator_list, axi_accelerator_list, cache_list, dma_width
         f.write("    );\n")
         f.write("\n")
         f.write("    port (\n")
-        write_acc_interface(f, acc, dma_width, "acc_rst", False, False, False)
+        write_acc_interface(f, acc, dma_width, "", "acc_rst", False, False, False)
         f.write("    );\n")
         f.write("  end component;\n\n")
         f.write("\n")
@@ -1025,7 +1044,7 @@ def gen_tech_indep_impl(accelerator_list, cache_list, dma_width, template_dir, o
           f.write("    );\n")
           f.write("\n")
           f.write("    port (\n")
-          write_acc_interface(f, acc, dma_width, "acc_rst", False, False, False)
+          write_acc_interface(f, acc, dma_width, "", "acc_rst", False, False, False)
           f.write("    );\n")
           f.write("\n")
           f.write("end entity " + acc.name + "_rtl;\n\n")
@@ -1046,7 +1065,7 @@ def gen_tech_indep_impl(accelerator_list, cache_list, dma_width, template_dir, o
             f.write("\n")
             f.write("  impl_" + impl.name + "_gen: if hls_conf = HLSCFG_" + acc.name.upper() + "_" + impl.name.upper() + " generate\n")
             f.write("    " + acc.name + "_" + impl.name + "_i: " + acc.name + "_" + impl.name + "\n")
-            write_acc_port_map(f, acc, dma_width, "rst", False, False, True, False)
+            write_acc_port_map(f, acc, dma_width, impl.datatype, "rst", False, False, True, False)
             f.write("\n\n")
             f.write("  -- CONF_DONE FSM\n")
             f.write("\n")
@@ -1099,7 +1118,7 @@ def gen_tech_indep_impl(accelerator_list, cache_list, dma_width, template_dir, o
           f.write("    );\n")
           f.write("\n")
           f.write("    port (\n")
-          write_acc_interface(f, acc, dma_width, "acc_rst", False, False, False)
+          write_acc_interface(f, acc, dma_width, "", "acc_rst", False, False, False)
           f.write("    );\n")
           f.write("\n")
           f.write("end entity " + acc.name + "_rtl;\n\n")
@@ -1110,7 +1129,7 @@ def gen_tech_indep_impl(accelerator_list, cache_list, dma_width, template_dir, o
             f.write("\n")
             f.write("  impl_" + impl.name + "_gen: if hls_conf = HLSCFG_" + acc.name.upper() + "_" + impl.name.upper() + " generate\n")
             f.write("    " + acc.name + "_" + impl.name + "_i: " + acc.name + "_" + impl.name + "\n")
-            write_acc_port_map(f, acc, dma_width, "rst", False, False, False, True)
+            write_acc_port_map(f, acc, dma_width, impl.datatype, "rst", False, False, False, True)
             f.write("  end generate impl_" +  impl.name + "_gen;\n\n")
           f.write("end mapping;\n\n")
         else:
@@ -1125,7 +1144,7 @@ def gen_tech_indep_impl(accelerator_list, cache_list, dma_width, template_dir, o
           f.write("    );\n")
           f.write("\n")
           f.write("    port (\n")
-          write_acc_interface(f, acc, dma_width, "acc_rst", False, False, False)
+          write_acc_interface(f, acc, dma_width, "", "acc_rst", False, False, False)
           f.write("    );\n")
           f.write("\n")
           f.write("end entity " + acc.name + "_rtl;\n\n")
@@ -1139,10 +1158,10 @@ def gen_tech_indep_impl(accelerator_list, cache_list, dma_width, template_dir, o
             f.write("  impl_" + impl.name + "_gen: if hls_conf = HLSCFG_" + acc.name.upper() + "_" + impl.name.upper() + " generate\n")
             if acc.hls_tool == 'stratus_hls':
               f.write("    " + acc.name + "_" + impl.name + "_i: " + acc.name + "_" + impl.name + "\n")
-              write_acc_port_map(f, acc, dma_width, "rst", False, False, False, False)
+              write_acc_port_map(f, acc, dma_width, impl.datatype, "rst", False, False, False, False)
             else:
               f.write("    " + acc.name + "_" + impl.name + "_top_i: " + acc.name + "_" + impl.name + "_top\n")
-              write_acc_port_map(f, acc, dma_width, "rst", False, True, False, False)
+              write_acc_port_map(f, acc, dma_width, impl.datatype, "rst", False, True, False, False)
             f.write("  end generate impl_" +  impl.name + "_gen;\n\n")
           f.write("end mapping;\n\n")
   f.close()
@@ -1353,7 +1372,7 @@ def gen_noc_interface(acc, dma_width, template_dir, out_dir, is_axi):
           f.write("    generic map (\n")
           f.write("      hls_conf => hls_conf\n")
           f.write("    )\n")
-          write_acc_port_map(f, acc, dma_width, "acc_rst", True, False, False, False)
+          write_acc_port_map(f, acc, dma_width, "", "acc_rst", True, False, False, False)
       else:
         f.write(tline)
 
@@ -1542,12 +1561,20 @@ for acc in accelerators:
     dp = dp_str.replace(acc + "_", "")
     dp_info = dp.split("_")
     skip = False
+    datatype = ""
     for item in dp_info:
       if re.match(r'dma[1-9]+', item, re.M|re.I):
         dp_dma_width = int(item.replace("dma", ""))
         if dp_dma_width != dma_width:
           skip = True
           break;
+      if re.match(r'flin', item, re.M|re.I):
+        datatype = "float_in"
+      elif re.match(r'flout', item, re.M|re.I):
+        datatype = "float_out"
+      elif re.match(r'fl', item, re.M|re.I):
+        datatype = "float"
+
     if skip:
       print("    INFO: System DMA_WIDTH is " + str(dma_width) + "; skipping " + acc + "_" + dp)
       continue
@@ -1555,6 +1582,7 @@ for acc in accelerators:
     impl = Implementation()
     impl.name = dp
     impl.dma_width = dma_width
+    impl.datatype = datatype
     accd.hlscfg.append(impl)
 
   # Read accelerator parameters and info

--- a/utils/sldgen/sld_generate.py
+++ b/utils/sldgen/sld_generate.py
@@ -1568,11 +1568,11 @@ for acc in accelerators:
         if dp_dma_width != dma_width:
           skip = True
           break;
-      if re.match(r'flin', item, re.M|re.I):
+      if re.fullmatch(r'fl32in', item):
         datatype = "float_in"
-      elif re.match(r'flout', item, re.M|re.I):
+      elif re.fullmatch(r'fl32out', item):
         datatype = "float_out"
-      elif re.match(r'fl', item, re.M|re.I):
+      elif re.fullmatch(r'fl32', item):
         datatype = "float"
 
     if skip:


### PR DESCRIPTION
Improvements to the Vivado HLS accelerator design and integration flow:
* commit 90c8e91c7fbd80e2e58f0cbcf4be08703671af00: add automatic integration of IPs generated by Vivado HLS
* commit dde8b86557e40fa0420dc5dc58fbc932f5211f01: add support for Vivado HLS accelerators with float interfaces

This PR resolves issue #44.