### PR TITLE
Consolidating and cleaning up RTL, automation tools and software (part 2)

### DIFF
--- a/accelerators/chisel/adder_chisel/sw/linux/app/cfg.h
+++ b/accelerators/chisel/adder_chisel/sw/linux/app/cfg.h
@@ -2,7 +2,7 @@
 #define __ESP_CFG_000_H__
 
 #include "libesp.h"
-#include "adder.h"
+#include "adder_chisel.h"
 
 typedef int32_t token_t;
 
@@ -15,7 +15,7 @@ const int32_t writeAddr = 0;
 
 #define NACC 1
 
-struct adder_access adder_cfg_000[] = {
+struct adder_chisel_access adder_cfg_000[] = {
 	{
 		/* <<--descriptor-->> */
 		.size = SIZE,
@@ -34,7 +34,7 @@ esp_thread_info_t cfg_000[] = {
 	{
 		.run = true,
 		.devname = "adder_chisel.0",
-		.ioctl_req = ADDER_IOC_ACCESS,
+		.ioctl_req = ADDER_CHISEL_IOC_ACCESS,
 		.esp_desc = &(adder_cfg_000[0].esp),
 	}
 };

--- a/accelerators/chisel/adder_chisel/sw/linux/driver/Kbuild
+++ b/accelerators/chisel/adder_chisel/sw/linux/driver/Kbuild
@@ -1,3 +1,3 @@
 EXTRA_CFLAGS += \
 	     -I$(DRIVERS)/include -I$(DRIVERS)/../common/include -I$(ACC_SW)/linux/include
-obj-m := adder.o
+obj-m := adder_chisel.o

--- a/accelerators/chisel/adder_chisel/sw/linux/include/adder_chisel.h
+++ b/accelerators/chisel/adder_chisel/sw/linux/include/adder_chisel.h
@@ -1,5 +1,5 @@
-#ifndef _VITDODEC_H_
-#define _VITDODEC_H_
+#ifndef _ADDER_CHISEL_H_
+#define _ADDER_CHISEL_H_
 
 #ifdef __KERNEL__
 #include <linux/ioctl.h>
@@ -15,16 +15,16 @@
 #include <esp.h>
 #include <esp_accelerator.h>
 
-struct vitdodec_access {
+struct adder_chisel_access {
 	struct esp_access esp;
 	/* <<--regs-->> */
-	unsigned cbps;
-	unsigned ntraceback;
-	unsigned data_bits;
+	unsigned size;
+	unsigned readAddr;
+	unsigned writeAddr;
 	unsigned src_offset;
 	unsigned dst_offset;
 };
 
-#define VITDODEC_IOC_ACCESS	_IOW ('S', 0, struct vitdodec_access)
+#define ADDER_CHISEL_IOC_ACCESS	_IOW ('S', 0, struct adder_chisel_access)
 
-#endif /* _VITDODEC_H_ */
+#endif /* _ADDER_CHISEL_H_ */

--- a/accelerators/chisel/counter_chisel/sw/linux/app/counter.c
+++ b/accelerators/chisel/counter_chisel/sw/linux/app/counter.c
@@ -8,18 +8,18 @@
 #include <my_stringify.h>
 #include <test/test.h>
 #include <test/time.h>
-#include <counter.h>
+#include <counter_chisel.h>
 
 #define DEVNAME "/dev/counter_chisel.0"
 #define NAME "counter_chisel"
 
-static const char usage_str[] = "usage: counter <ticks>\n"
+static const char usage_str[] = "usage: counter_chisel <ticks>\n"
 	"  ticks: counter initialization\n"
 	"\n";
 
 struct counter_test {
 	struct test_info info;
-	struct counter_access desc;
+	struct counter_chisel_access desc;
 	unsigned int ticks;
 };
 
@@ -70,7 +70,7 @@ static struct counter_test counter_test = {
 		.set_access	= counter_set_access,
 		.diff_ok	= counter_diff_ok,
 		.esp		= &counter_test.desc.esp,
-		.cm		= COUNTER_IOC_ACCESS,
+		.cm		= COUNTER_CHISEL_IOC_ACCESS,
 	},
 };
 

--- a/accelerators/chisel/counter_chisel/sw/linux/driver/Kbuild
+++ b/accelerators/chisel/counter_chisel/sw/linux/driver/Kbuild
@@ -1,3 +1,3 @@
 EXTRA_CFLAGS += \
 	     -I$(DRIVERS)/include -I$(DRIVERS)/../common/include -I$(ACC_SW)/linux/include
-obj-m := counter.o
+obj-m := counter_chisel.o

--- a/accelerators/chisel/counter_chisel/sw/linux/driver/counter_chisel.c
+++ b/accelerators/chisel/counter_chisel/sw/linux/driver/counter_chisel.c
@@ -6,14 +6,14 @@
 #include <esp_accelerator.h>
 #include <esp.h>
 
-#include "counter.h"
+#include "counter_chisel.h"
 
 #define DRV_NAME	"counter_chisel"
 
 #define COUNTER_GITHASH_REG		0x40
 #define COUNTER_TICKS_REG		0x44
 
-struct counter_device {
+struct counter_chisel_device {
 	struct esp_device esp;
 };
 
@@ -34,21 +34,21 @@ static struct of_device_id counter_device_ids[] = {
 
 static int counter_devs;
 
-static inline struct counter_device *to_counter(struct esp_device *esp)
+static inline struct counter_chisel_device *to_counter(struct esp_device *esp)
 {
-	return container_of(esp, struct counter_device, esp);
+	return container_of(esp, struct counter_chisel_device, esp);
 }
 
 static void counter_prep_xfer(struct esp_device *esp, void *arg)
 {
-	struct counter_access *a = arg;
+	struct counter_chisel_access *a = arg;
 
 	iowrite32be(a->ticks, esp->iomem + COUNTER_TICKS_REG);
 }
 
 static bool counter_xfer_input_ok(struct esp_device *esp, void *arg)
 {
-	struct counter_access *a = arg;
+	struct counter_chisel_access *a = arg;
 
 	if (a->ticks >= (1<<16) || a->ticks < 1)
 		return false;
@@ -57,7 +57,7 @@ static bool counter_xfer_input_ok(struct esp_device *esp, void *arg)
 
 static int counter_probe(struct platform_device *pdev)
 {
-	struct counter_device *counter;
+	struct counter_chisel_device *counter;
 	struct esp_device *esp;
 	int rc;
 
@@ -82,7 +82,7 @@ static int counter_probe(struct platform_device *pdev)
 static int __exit counter_remove(struct platform_device *pdev)
 {
 	struct esp_device *esp = platform_get_drvdata(pdev);
-	struct counter_device *counter = to_counter(esp);
+	struct counter_chisel_device *counter = to_counter(esp);
 
 	esp_device_unregister(esp);
 	kfree(counter);
@@ -101,8 +101,8 @@ static struct esp_driver counter_driver = {
 	},
 	.xfer_input_ok	= counter_xfer_input_ok,
 	.prep_xfer	= counter_prep_xfer,
-	.ioctl_cm	= COUNTER_IOC_ACCESS,
-	.arg_size	= sizeof(struct counter_access),
+	.ioctl_cm	= COUNTER_CHISEL_IOC_ACCESS,
+	.arg_size	= sizeof(struct counter_chisel_access),
 };
 
 static int __init counter_init(void)
@@ -122,4 +122,4 @@ MODULE_DEVICE_TABLE(of, counter_device_ids);
 
 MODULE_AUTHOR("Emilio G. Cota <cota@braap.org>");
 MODULE_LICENSE("GPL");
-MODULE_DESCRIPTION("counter driver");
+MODULE_DESCRIPTION("counter_chisel driver");

--- a/accelerators/chisel/counter_chisel/sw/linux/include/counter_chisel.h
+++ b/accelerators/chisel/counter_chisel/sw/linux/include/counter_chisel.h
@@ -1,5 +1,5 @@
-#ifndef _SORT_H_
-#define _SORT_H_
+#ifndef _COUNTER_CHISEL_H_
+#define _COUNTER_CHISEL_H_
 
 #ifdef __KERNEL__
 #include <linux/ioctl.h>
@@ -15,12 +15,11 @@
 #include <esp.h>
 #include <esp_accelerator.h>
 
-struct sort_access {
+struct counter_chisel_access {
 	struct esp_access esp;
-	unsigned int size;
-	unsigned int batch;
+	unsigned int ticks;
 };
 
-#define SORT_IOC_ACCESS	_IOW ('S', 0, struct sort_access)
+#define COUNTER_CHISEL_IOC_ACCESS	_IOW ('S', 0, struct counter_chisel_access)
 
-#endif /* _SORT_H_ */
+#endif /* _COUNTER_CHISEL_H_ */

--- a/accelerators/chisel/fft_chisel/sw/linux/app/cfg.h
+++ b/accelerators/chisel/fft_chisel/sw/linux/app/cfg.h
@@ -2,7 +2,7 @@
 #define __ESP_CFG_000_H__
 
 #include "libesp.h"
-#include "fft.h"
+#include "fft_chisel.h"
 
 typedef int32_t token_t;
 
@@ -16,7 +16,7 @@ const int32_t log_len = LOG_LEN;
 
 #define NACC 1
 
-struct fft_access fft_cfg_000[] = {
+struct fft_chisel_access fft_cfg_000[] = {
 	{
 		/* <<--descriptor-->> */
 		.stride = LEN,
@@ -34,7 +34,7 @@ esp_thread_info_t cfg_000[] = {
 	{
 		.run = true,
 		.devname = "fft_chisel.0",
-		.ioctl_req = FFT_IOC_ACCESS,
+		.ioctl_req = FFT_CHISEL_IOC_ACCESS,
 		.esp_desc = &(fft_cfg_000[0].esp),
 	}
 };

--- a/accelerators/chisel/fft_chisel/sw/linux/driver/Kbuild
+++ b/accelerators/chisel/fft_chisel/sw/linux/driver/Kbuild
@@ -1,3 +1,3 @@
 EXTRA_CFLAGS += \
 	     -I$(DRIVERS)/include -I$(DRIVERS)/../common/include -I$(ACC_SW)/linux/include
-obj-m := fft.o
+obj-m := fft_chisel.o

--- a/accelerators/chisel/fft_chisel/sw/linux/driver/fft_chisel.c
+++ b/accelerators/chisel/fft_chisel/sw/linux/driver/fft_chisel.c
@@ -6,7 +6,7 @@
 #include <esp_accelerator.h>
 #include <esp.h>
 
-#include "fft.h"
+#include "fft_chisel.h"
 
 #define DRV_NAME	"fft_chisel"
 
@@ -15,7 +15,7 @@
 #define FFT_COUNT_REG 0x4C
 #define FFT_STARTADDR_REG 0x48
 
-struct fft_device {
+struct fft_chisel_device {
 	struct esp_device esp;
 };
 
@@ -36,14 +36,14 @@ static struct of_device_id fft_device_ids[] = {
 
 static int fft_devs;
 
-static inline struct fft_device *to_fft(struct esp_device *esp)
+static inline struct fft_chisel_device *to_fft(struct esp_device *esp)
 {
-	return container_of(esp, struct fft_device, esp);
+	return container_of(esp, struct fft_chisel_device, esp);
 }
 
 static void fft_prep_xfer(struct esp_device *esp, void *arg)
 {
-	struct fft_access *a = arg;
+	struct fft_chisel_access *a = arg;
 
 	/* <<--regs-config-->> */
 	iowrite32be(a->stride, esp->iomem + FFT_STRIDE_REG);
@@ -56,15 +56,15 @@ static void fft_prep_xfer(struct esp_device *esp, void *arg)
 
 static bool fft_xfer_input_ok(struct esp_device *esp, void *arg)
 {
-	/* struct fft_device *fft = to_fft(esp); */
-	/* struct fft_access *a = arg; */
+	/* struct fft_chisel_device *fft = to_fft(esp); */
+	/* struct fft_chisel_access *a = arg; */
 
 	return true;
 }
 
 static int fft_probe(struct platform_device *pdev)
 {
-	struct fft_device *fft;
+	struct fft_chisel_device *fft;
 	struct esp_device *esp;
 	int rc;
 
@@ -89,7 +89,7 @@ static int fft_probe(struct platform_device *pdev)
 static int __exit fft_remove(struct platform_device *pdev)
 {
 	struct esp_device *esp = platform_get_drvdata(pdev);
-	struct fft_device *fft = to_fft(esp);
+	struct fft_chisel_device *fft = to_fft(esp);
 
 	esp_device_unregister(esp);
 	kfree(fft);
@@ -108,8 +108,8 @@ static struct esp_driver fft_driver = {
 	},
 	.xfer_input_ok	= fft_xfer_input_ok,
 	.prep_xfer	= fft_prep_xfer,
-	.ioctl_cm	= FFT_IOC_ACCESS,
-	.arg_size	= sizeof(struct fft_access),
+	.ioctl_cm	= FFT_CHISEL_IOC_ACCESS,
+	.arg_size	= sizeof(struct fft_chisel_access),
 };
 
 static int __init fft_init(void)
@@ -129,4 +129,4 @@ MODULE_DEVICE_TABLE(of, fft_device_ids);
 
 MODULE_AUTHOR("Emilio G. Cota <cota@braap.org>");
 MODULE_LICENSE("GPL");
-MODULE_DESCRIPTION("fft driver");
+MODULE_DESCRIPTION("fft_chisel driver");

--- a/accelerators/chisel/fft_chisel/sw/linux/include/fft_chisel.h
+++ b/accelerators/chisel/fft_chisel/sw/linux/include/fft_chisel.h
@@ -1,5 +1,5 @@
-#ifndef _DUMMY_H_
-#define _DUMMY_H_
+#ifndef _FFT_CHISEL_H_
+#define _FFT_CHISEL_H_
 
 #ifdef __KERNEL__
 #include <linux/ioctl.h>
@@ -15,14 +15,14 @@
 #include <esp.h>
 #include <esp_accelerator.h>
 
-struct dummy_access {
+struct fft_chisel_access {
 	struct esp_access esp;
-	unsigned tokens;
-	unsigned batch;
+	/* <<--regs-->> */
+	unsigned stride;
 	unsigned src_offset;
 	unsigned dst_offset;
 };
 
-#define DUMMY_IOC_ACCESS	_IOW ('S', 0, struct dummy_access)
+#define FFT_CHISEL_IOC_ACCESS	_IOW ('S', 0, struct fft_chisel_access)
 
-#endif /* _DUMMY_H_ */
+#endif /* _FFT_CHISEL_H_ */

--- a/accelerators/stratus_hls/dummy_stratus/sw/linux/app/dummy.c
+++ b/accelerators/stratus_hls/dummy_stratus/sw/linux/app/dummy.c
@@ -9,7 +9,7 @@
 #include <my_stringify.h>
 #include <test/test.h>
 #include <test/time.h>
-#include <dummy.h>
+#include <dummy_stratus.h>
 
 #define TOKENS 8
 #define BATCH 2
@@ -21,7 +21,7 @@ static unsigned size;
 
 struct accelerator_thread_info {
 	int fd;
-	struct dummy_access desc;
+	struct dummy_stratus_access desc;
 	unsigned long long hw_ns;
 };
 
@@ -35,7 +35,7 @@ void *accelerator_thread( void *ptr )
 	int rc;
 
 	gettime(&th_start);
-	rc = ioctl(info->fd, DUMMY_IOC_ACCESS, info->desc);
+	rc = ioctl(info->fd, DUMMY_STRATUS_IOC_ACCESS, info->desc);
 	gettime(&th_end);
 	if(rc < 0) {
 		perror("ioctl");
@@ -46,7 +46,7 @@ void *accelerator_thread( void *ptr )
 	return NULL;
 }
 
-static void prepare_dummy(int *fd, contig_handle_t *mem, accelerator_thread_info_t *info, struct dummy_access *desc, const char *device_name, unsigned id, unsigned do_p2p)
+static void prepare_dummy(int *fd, contig_handle_t *mem, accelerator_thread_info_t *info, struct dummy_stratus_access *desc, const char *device_name, unsigned id, unsigned do_p2p)
 {
 		*fd = open(device_name, O_RDWR, 0);
 		if (*fd < 0) {
@@ -148,7 +148,7 @@ int main(int argc, char *argv[])
 
 	pthread_t thread[3];
 	accelerator_thread_info_t info[3];
-	struct dummy_access desc[3];
+	struct dummy_stratus_access desc[3];
 
 	void *rp;
 

--- a/accelerators/stratus_hls/dummy_stratus/sw/linux/driver/Kbuild
+++ b/accelerators/stratus_hls/dummy_stratus/sw/linux/driver/Kbuild
@@ -1,3 +1,3 @@
 EXTRA_CFLAGS += \
 	     -I$(DRIVERS)/include -I$(DRIVERS)/../common/include -I$(ACC_SW)/linux/include
-obj-m := dummy.o
+obj-m := dummy_stratus.o

--- a/accelerators/stratus_hls/dummy_stratus/sw/linux/driver/dummy_stratus.c
+++ b/accelerators/stratus_hls/dummy_stratus/sw/linux/driver/dummy_stratus.c
@@ -6,14 +6,14 @@
 #include <esp_accelerator.h>
 #include <esp.h>
 
-#include "dummy.h"
+#include "dummy_stratus.h"
 
 #define DRV_NAME	"dummy_stratus"
 
 #define DUMMY_LEN_REG		0x40
 #define DUMMY_BATCH_REG		0x44
 
-struct dummy_device {
+struct dummy_stratus_device {
 	struct esp_device esp;
 };
 
@@ -34,14 +34,14 @@ static struct of_device_id dummy_device_ids[] = {
 
 static int dummy_devs;
 
-static inline struct dummy_device *to_dummy(struct esp_device *esp)
+static inline struct dummy_stratus_device *to_dummy(struct esp_device *esp)
 {
-	return container_of(esp, struct dummy_device, esp);
+	return container_of(esp, struct dummy_stratus_device, esp);
 }
 
 static void dummy_prep_xfer(struct esp_device *esp, void *arg)
 {
-	struct dummy_access *a = arg;
+	struct dummy_stratus_access *a = arg;
 
 	iowrite32be(a->tokens, esp->iomem + DUMMY_LEN_REG);
 	iowrite32be(a->batch, esp->iomem + DUMMY_BATCH_REG);
@@ -52,15 +52,15 @@ static void dummy_prep_xfer(struct esp_device *esp, void *arg)
 
 static bool dummy_xfer_input_ok(struct esp_device *esp, void *arg)
 {
-	/* struct dummy_device *dummy = to_dummy(esp); */
-	/* struct dummy_access *a = arg; */
+	/* struct dummy_stratus_device *dummy = to_dummy(esp); */
+	/* struct dummy_stratus_access *a = arg; */
 
 	return true;
 }
 
 static int dummy_probe(struct platform_device *pdev)
 {
-	struct dummy_device *dummy;
+	struct dummy_stratus_device *dummy;
 	struct esp_device *esp;
 	int rc;
 
@@ -85,7 +85,7 @@ static int dummy_probe(struct platform_device *pdev)
 static int __exit dummy_remove(struct platform_device *pdev)
 {
 	struct esp_device *esp = platform_get_drvdata(pdev);
-	struct dummy_device *dummy = to_dummy(esp);
+	struct dummy_stratus_device *dummy = to_dummy(esp);
 
 	esp_device_unregister(esp);
 	kfree(dummy);
@@ -104,8 +104,8 @@ static struct esp_driver dummy_driver = {
 	},
 	.xfer_input_ok	= dummy_xfer_input_ok,
 	.prep_xfer	= dummy_prep_xfer,
-	.ioctl_cm	= DUMMY_IOC_ACCESS,
-	.arg_size	= sizeof(struct dummy_access),
+	.ioctl_cm	= DUMMY_STRATUS_IOC_ACCESS,
+	.arg_size	= sizeof(struct dummy_stratus_access),
 };
 
 static int __init dummy_init(void)
@@ -125,4 +125,4 @@ MODULE_DEVICE_TABLE(of, dummy_device_ids);
 
 MODULE_AUTHOR("Emilio G. Cota <cota@braap.org>");
 MODULE_LICENSE("GPL");
-MODULE_DESCRIPTION("dummy driver");
+MODULE_DESCRIPTION("dummy_stratus driver");

--- a/accelerators/stratus_hls/dummy_stratus/sw/linux/include/dummy_stratus.h
+++ b/accelerators/stratus_hls/dummy_stratus/sw/linux/include/dummy_stratus.h
@@ -1,5 +1,5 @@
-#ifndef _ADDER_H_
-#define _ADDER_H_
+#ifndef _DUMMY_STRATUS_H_
+#define _DUMMY_STRATUS_H_
 
 #ifdef __KERNEL__
 #include <linux/ioctl.h>
@@ -15,16 +15,14 @@
 #include <esp.h>
 #include <esp_accelerator.h>
 
-struct adder_access {
+struct dummy_stratus_access {
 	struct esp_access esp;
-	/* <<--regs-->> */
-	unsigned size;
-	unsigned readAddr;
-	unsigned writeAddr;
+	unsigned tokens;
+	unsigned batch;
 	unsigned src_offset;
 	unsigned dst_offset;
 };
 
-#define ADDER_IOC_ACCESS	_IOW ('S', 0, struct adder_access)
+#define DUMMY_STRATUS_IOC_ACCESS	_IOW ('S', 0, struct dummy_stratus_access)
 
-#endif /* _ADDER_H_ */
+#endif /* _DUMMY_STRATUS_H_ */

--- a/accelerators/stratus_hls/fft_stratus/sw/linux/app/cfg.h
+++ b/accelerators/stratus_hls/fft_stratus/sw/linux/app/cfg.h
@@ -2,7 +2,7 @@
 #define __ESP_CFG_000_H__
 
 #include "libesp.h"
-#include "fft.h"
+#include "fft_stratus.h"
 
 #if (FFT_FX_WIDTH == 64)
 typedef unsigned long long token_t;
@@ -30,7 +30,7 @@ const int32_t log_len = LOG_LEN;
 
 #define NACC 1
 
-struct fft_access fft_cfg_000[] = {
+struct fft_stratus_access fft_cfg_000[] = {
 	{
 		/* <<--descriptor-->> */
 		.do_bitrev = DO_BITREV,
@@ -48,7 +48,7 @@ esp_thread_info_t cfg_000[] = {
 	{
 		.run = true,
 		.devname = "fft_stratus.0",
-		.ioctl_req = FFT_IOC_ACCESS,
+		.ioctl_req = FFT_STRATUS_IOC_ACCESS,
 		.esp_desc = &(fft_cfg_000[0].esp),
 	}
 };

--- a/accelerators/stratus_hls/fft_stratus/sw/linux/driver/Kbuild
+++ b/accelerators/stratus_hls/fft_stratus/sw/linux/driver/Kbuild
@@ -1,3 +1,3 @@
 EXTRA_CFLAGS += \
 	     -I$(DRIVERS)/include -I$(DRIVERS)/../common/include -I$(ACC_SW)/linux/include
-obj-m := fft.o
+obj-m := fft_stratus.o

--- a/accelerators/stratus_hls/fft_stratus/sw/linux/driver/fft_stratus.c
+++ b/accelerators/stratus_hls/fft_stratus/sw/linux/driver/fft_stratus.c
@@ -6,7 +6,7 @@
 #include <esp_accelerator.h>
 #include <esp.h>
 
-#include "fft.h"
+#include "fft_stratus.h"
 
 #define DRV_NAME	"fft_stratus"
 
@@ -15,7 +15,7 @@
 #define FFT_DO_BITREV_REG 0x44
 #define FFT_LOG_LEN_REG 0x40
 
-struct fft_device {
+struct fft_stratus_device {
 	struct esp_device esp;
 };
 
@@ -36,14 +36,14 @@ static struct of_device_id fft_device_ids[] = {
 
 static int fft_devs;
 
-static inline struct fft_device *to_fft(struct esp_device *esp)
+static inline struct fft_stratus_device *to_fft(struct esp_device *esp)
 {
-	return container_of(esp, struct fft_device, esp);
+	return container_of(esp, struct fft_stratus_device, esp);
 }
 
 static void fft_prep_xfer(struct esp_device *esp, void *arg)
 {
-	struct fft_access *a = arg;
+	struct fft_stratus_access *a = arg;
 
 	/* <<--regs-config-->> */
 	iowrite32be(0, esp->iomem + FFT_DO_PEAK_REG);
@@ -56,15 +56,15 @@ static void fft_prep_xfer(struct esp_device *esp, void *arg)
 
 static bool fft_xfer_input_ok(struct esp_device *esp, void *arg)
 {
-	/* struct fft_device *fft = to_fft(esp); */
-	/* struct fft_access *a = arg; */
+	/* struct fft_stratus_device *fft = to_fft(esp); */
+	/* struct fft_stratus_access *a = arg; */
 
 	return true;
 }
 
 static int fft_probe(struct platform_device *pdev)
 {
-	struct fft_device *fft;
+	struct fft_stratus_device *fft;
 	struct esp_device *esp;
 	int rc;
 
@@ -89,7 +89,7 @@ static int fft_probe(struct platform_device *pdev)
 static int __exit fft_remove(struct platform_device *pdev)
 {
 	struct esp_device *esp = platform_get_drvdata(pdev);
-	struct fft_device *fft = to_fft(esp);
+	struct fft_stratus_device *fft = to_fft(esp);
 
 	esp_device_unregister(esp);
 	kfree(fft);
@@ -108,8 +108,8 @@ static struct esp_driver fft_driver = {
 	},
 	.xfer_input_ok	= fft_xfer_input_ok,
 	.prep_xfer	= fft_prep_xfer,
-	.ioctl_cm	= FFT_IOC_ACCESS,
-	.arg_size	= sizeof(struct fft_access),
+	.ioctl_cm	= FFT_STRATUS_IOC_ACCESS,
+	.arg_size	= sizeof(struct fft_stratus_access),
 };
 
 static int __init fft_init(void)
@@ -129,4 +129,4 @@ MODULE_DEVICE_TABLE(of, fft_device_ids);
 
 MODULE_AUTHOR("Emilio G. Cota <cota@braap.org>");
 MODULE_LICENSE("GPL");
-MODULE_DESCRIPTION("fft driver");
+MODULE_DESCRIPTION("fft_stratus driver");

--- a/accelerators/stratus_hls/fft_stratus/sw/linux/include/fft_stratus.h
+++ b/accelerators/stratus_hls/fft_stratus/sw/linux/include/fft_stratus.h
@@ -1,5 +1,5 @@
-#ifndef _FFT_H_
-#define _FFT_H_
+#ifndef _FFT_STRATUS_H_
+#define _FFT_STRATUS_H_
 
 #ifdef __KERNEL__
 #include <linux/ioctl.h>
@@ -15,7 +15,7 @@
 #include <esp.h>
 #include <esp_accelerator.h>
 
-struct fft_access {
+struct fft_stratus_access {
 	struct esp_access esp;
 	/* <<--regs-->> */
 	unsigned log_len;
@@ -25,6 +25,6 @@ struct fft_access {
 
 };
 
-#define FFT_IOC_ACCESS	_IOW ('S', 0, struct fft_access)
+#define FFT_STRATUS_IOC_ACCESS	_IOW ('S', 0, struct fft_stratus_access)
 
-#endif /* _FFT_H_ */
+#endif /* _FFT_STRATUS_H_ */

--- a/accelerators/stratus_hls/nightvision_stratus/sw/linux/app/nightvision.c
+++ b/accelerators/stratus_hls/nightvision_stratus/sw/linux/app/nightvision.c
@@ -8,7 +8,7 @@
 #include <my_stringify.h>
 #include <test/test.h>
 #include <test/time.h>
-#include <nightvision.h>
+#include <nightvision_stratus.h>
 
 #include <assert.h>
 #include <errno.h>
@@ -591,7 +591,7 @@ int ensemble_1(algPixel_t *streamA, algPixel_t *out, int nRows, int nCols,
 }
 
 static const char usage_str[] =
-	"usage: ./nightvision.exe coherence infile [nimages] [ncols] [nrows] [-v]\n"
+	"usage: ./nightvision_stratus.exe coherence infile [nimages] [ncols] [nrows] [-v]\n"
 	"  coherence: none|llc-coh-dma|coh-dma|coh\n"
 	"  infile : input file name (includes the path)\n"
 	"\n"
@@ -609,7 +609,7 @@ static const char usage_str[] =
 
 struct nightvision_test {
 	struct test_info info;
-	struct nightvision_access desc;
+	struct nightvision_stratus_access desc;
 	char *infile;
         bool infile_is_raw;
 	unsigned nimages;
@@ -879,7 +879,7 @@ static struct nightvision_test nightvision_test = {
 		.comp		= nightvision_comp,
 		.diff_ok	= nightvision_diff_ok,
 		.esp		= &nightvision_test.desc.esp,
-		.cm		= NIGHTVISION_IOC_ACCESS,
+		.cm		= NIGHTVISION_STRATUS_IOC_ACCESS,
 	},
 };
 

--- a/accelerators/stratus_hls/nightvision_stratus/sw/linux/driver/Kbuild
+++ b/accelerators/stratus_hls/nightvision_stratus/sw/linux/driver/Kbuild
@@ -1,3 +1,3 @@
 EXTRA_CFLAGS += \
 	     -I$(DRIVERS)/include -I$(DRIVERS)/../common/include -I$(ACC_SW)/linux/include
-obj-m := nightvision.o
+obj-m := nightvision_stratus.o

--- a/accelerators/stratus_hls/nightvision_stratus/sw/linux/driver/nightvision_stratus.c
+++ b/accelerators/stratus_hls/nightvision_stratus/sw/linux/driver/nightvision_stratus.c
@@ -7,7 +7,7 @@
 #include <esp_accelerator.h>
 #include <esp.h>
 
-#include "nightvision.h"
+#include "nightvision_stratus.h"
 
 #define DRV_NAME	"nightvision_stratus"
 
@@ -16,7 +16,7 @@
 #define NIGHTVISION_COLS_REG	0x48
 #define NIGHTVISION_DO_DWT_REG	0x4C
 
-struct nightvision_device {
+struct nightvision_stratus_device {
 	struct esp_device esp;
 };
 
@@ -37,14 +37,14 @@ static struct of_device_id nightvision_device_ids[] = {
 
 static int nightvision_devs;
 
-static inline struct nightvision_device *to_nightvision(struct esp_device *esp)
+static inline struct nightvision_stratus_device *to_nightvision(struct esp_device *esp)
 {
-	return container_of(esp, struct nightvision_device, esp);
+	return container_of(esp, struct nightvision_stratus_device, esp);
 }
 
 static void nightvision_prep_xfer(struct esp_device *esp, void *arg)
 {
-	struct nightvision_access *a = arg;
+	struct nightvision_stratus_access *a = arg;
 
 	iowrite32be(a->nimages, esp->iomem + NIGHTVISION_NIMAGES_REG);
 	iowrite32be(a->rows, esp->iomem + NIGHTVISION_ROWS_REG);
@@ -56,7 +56,7 @@ static void nightvision_prep_xfer(struct esp_device *esp, void *arg)
 
 static bool nightvision_xfer_input_ok(struct esp_device *esp, void *arg)
 {
-	struct nightvision_access *a = arg;
+	struct nightvision_stratus_access *a = arg;
 
         if (a->nimages > MAX_NIMAGES)
 	        return false;
@@ -75,7 +75,7 @@ static bool nightvision_xfer_input_ok(struct esp_device *esp, void *arg)
 
 static int nightvision_probe(struct platform_device *pdev)
 {
-	struct nightvision_device *nightvision;
+	struct nightvision_stratus_device *nightvision;
 	struct esp_device *esp;
 	int rc;
 
@@ -100,7 +100,7 @@ static int nightvision_probe(struct platform_device *pdev)
 static int __exit nightvision_remove(struct platform_device *pdev)
 {
 	struct esp_device *esp = platform_get_drvdata(pdev);
-	struct nightvision_device *nightvision = to_nightvision(esp);
+	struct nightvision_stratus_device *nightvision = to_nightvision(esp);
 
 	esp_device_unregister(esp);
 	kfree(nightvision);
@@ -119,8 +119,8 @@ static struct esp_driver nightvision_driver = {
 	},
 	.xfer_input_ok	= nightvision_xfer_input_ok,
 	.prep_xfer	= nightvision_prep_xfer,
-	.ioctl_cm	= NIGHTVISION_IOC_ACCESS,
-	.arg_size	= sizeof(struct nightvision_access),
+	.ioctl_cm	= NIGHTVISION_STRATUS_IOC_ACCESS,
+	.arg_size	= sizeof(struct nightvision_stratus_access),
 };
 
 static int __init nightvision_init(void)
@@ -140,4 +140,4 @@ MODULE_DEVICE_TABLE(of, nightvision_device_ids);
 
 MODULE_AUTHOR("Emilio G. Cota <cota@braap.org>");
 MODULE_LICENSE("GPL");
-MODULE_DESCRIPTION("nightvision driver");
+MODULE_DESCRIPTION("nightvision_stratus driver");

--- a/accelerators/stratus_hls/nightvision_stratus/sw/linux/include/nightvision_stratus.h
+++ b/accelerators/stratus_hls/nightvision_stratus/sw/linux/include/nightvision_stratus.h
@@ -1,5 +1,5 @@
-#ifndef _NIGHTVISION_H_
-#define _NIGHTVISION_H_
+#ifndef _NIGHTVISION_STRATUS_H_
+#define _NIGHTVISION_STRATUS_H_
 
 #ifdef __KERNEL__
 #include <linux/ioctl.h>
@@ -19,7 +19,7 @@
 #define MAX_ROWS 2048
 #define MAX_COLS 2048
 
-struct nightvision_access {
+struct nightvision_stratus_access {
 	struct esp_access esp;
 	// Number of images to be processed
 	unsigned int nimages;
@@ -35,6 +35,6 @@ struct nightvision_access {
 	unsigned dst_offset;
 };
 
-#define NIGHTVISION_IOC_ACCESS	_IOW ('S', 0, struct nightvision_access)
+#define NIGHTVISION_STRATUS_IOC_ACCESS	_IOW ('S', 0, struct nightvision_stratus_access)
 
-#endif /* _NIGHTVISION_H_ */
+#endif /* _NIGHTVISION_STRATUS_H_ */

--- a/accelerators/stratus_hls/sort_stratus/sw/linux/app/sort.c
+++ b/accelerators/stratus_hls/sort_stratus/sw/linux/app/sort.c
@@ -8,7 +8,7 @@
 #include <my_stringify.h>
 #include <test/test.h>
 #include <test/time.h>
-#include <sort.h>
+#include <sort_stratus.h>
 
 #define DEVNAME "/dev/sort_stratus.0"
 #define NAME "sort_stratus"
@@ -26,7 +26,7 @@ static const char usage_str[] = "usage: sort coherence cmd [n_elems] [n_batches]
 
 struct sort_test {
 	struct test_info info;
-	struct sort_access desc;
+	struct sort_stratus_access desc;
 	float *hbuf;
 	float *sbuf;
 	unsigned int n_elems;
@@ -260,7 +260,7 @@ static struct sort_test sort_test = {
 		.comp		= sort_comp,
 		.diff_ok	= sort_diff_ok,
 		.esp		= &sort_test.desc.esp,
-		.cm		= SORT_IOC_ACCESS,
+		.cm		= SORT_STRATUS_IOC_ACCESS,
 	},
 };
 

--- a/accelerators/stratus_hls/sort_stratus/sw/linux/driver/Kbuild
+++ b/accelerators/stratus_hls/sort_stratus/sw/linux/driver/Kbuild
@@ -1,3 +1,3 @@
 EXTRA_CFLAGS += \
 	     -I$(DRIVERS)/include -I$(DRIVERS)/../common/include -I$(ACC_SW)/linux/include
-obj-m := sort.o
+obj-m := sort_stratus.o

--- a/accelerators/stratus_hls/sort_stratus/sw/linux/driver/sort_stratus.c
+++ b/accelerators/stratus_hls/sort_stratus/sw/linux/driver/sort_stratus.c
@@ -6,7 +6,7 @@
 #include <esp_accelerator.h>
 #include <esp.h>
 
-#include "sort.h"
+#include "sort_stratus.h"
 
 #define DRV_NAME	"sort_stratus"
 
@@ -16,7 +16,7 @@
 #define SORT_LEN_MAX_REG	0x4c
 #define SORT_BATCH_MAX_REG	0x50
 
-struct sort_device {
+struct sort_stratus_device {
 	struct esp_device esp;
 	size_t max_size; /* Maximum buffer size to be DMA'd to/from in bytes */
 	unsigned min_len;
@@ -41,14 +41,14 @@ static struct of_device_id sort_device_ids[] = {
 
 static int sort_devs;
 
-static inline struct sort_device *to_sort(struct esp_device *esp)
+static inline struct sort_stratus_device *to_sort(struct esp_device *esp)
 {
-	return container_of(esp, struct sort_device, esp);
+	return container_of(esp, struct sort_stratus_device, esp);
 }
 
 static void sort_prep_xfer(struct esp_device *esp, void *arg)
 {
-	struct sort_access *a = arg;
+	struct sort_stratus_access *a = arg;
 
 	iowrite32be(a->size, esp->iomem + SORT_LEN_REG);
 	iowrite32be(a->batch, esp->iomem + SORT_BATCH_REG);
@@ -56,8 +56,8 @@ static void sort_prep_xfer(struct esp_device *esp, void *arg)
 
 static bool sort_xfer_input_ok(struct esp_device *esp, void *arg)
 {
-	struct sort_device *sort = to_sort(esp);
-	struct sort_access *a = arg;
+	struct sort_stratus_device *sort = to_sort(esp);
+	struct sort_stratus_access *a = arg;
 	unsigned size_mask = 0x0000001f;
 
 	if (a->size & size_mask ||
@@ -71,7 +71,7 @@ static bool sort_xfer_input_ok(struct esp_device *esp, void *arg)
 
 static int sort_probe(struct platform_device *pdev)
 {
-	struct sort_device *sort;
+	struct sort_stratus_device *sort;
 	struct esp_device *esp;
 	size_t max_size;
 	int rc;
@@ -102,7 +102,7 @@ static int sort_probe(struct platform_device *pdev)
 static int __exit sort_remove(struct platform_device *pdev)
 {
 	struct esp_device *esp = platform_get_drvdata(pdev);
-	struct sort_device *sort = to_sort(esp);
+	struct sort_stratus_device *sort = to_sort(esp);
 
 	esp_device_unregister(esp);
 	kfree(sort);
@@ -121,8 +121,8 @@ static struct esp_driver sort_driver = {
 	},
 	.xfer_input_ok	= sort_xfer_input_ok,
 	.prep_xfer	= sort_prep_xfer,
-	.ioctl_cm	= SORT_IOC_ACCESS,
-	.arg_size	= sizeof(struct sort_access),
+	.ioctl_cm	= SORT_STRATUS_IOC_ACCESS,
+	.arg_size	= sizeof(struct sort_stratus_access),
 };
 
 static int __init sort_init(void)
@@ -142,4 +142,4 @@ MODULE_DEVICE_TABLE(of, sort_device_ids);
 
 MODULE_AUTHOR("Emilio G. Cota <cota@braap.org>");
 MODULE_LICENSE("GPL");
-MODULE_DESCRIPTION("sort driver");
+MODULE_DESCRIPTION("sort_stratus driver");

--- a/accelerators/stratus_hls/sort_stratus/sw/linux/include/sort_stratus.h
+++ b/accelerators/stratus_hls/sort_stratus/sw/linux/include/sort_stratus.h
@@ -1,5 +1,5 @@
-#ifndef _COUNTER_H_
-#define _COUNTER_H_
+#ifndef _SORT_STRATUS_H_
+#define _SORT_STRATUS_H_
 
 #ifdef __KERNEL__
 #include <linux/ioctl.h>
@@ -15,11 +15,12 @@
 #include <esp.h>
 #include <esp_accelerator.h>
 
-struct counter_access {
+struct sort_stratus_access {
 	struct esp_access esp;
-	unsigned int ticks;
+	unsigned int size;
+	unsigned int batch;
 };
 
-#define COUNTER_IOC_ACCESS	_IOW ('S', 0, struct counter_access)
+#define SORT_STRATUS_IOC_ACCESS	_IOW ('S', 0, struct sort_stratus_access)
 
-#endif /* _COUNTER_H_ */
+#endif /* _SORT_STRATUS_H_ */

--- a/accelerators/stratus_hls/spmv_stratus/sw/linux/app/spmv.c
+++ b/accelerators/stratus_hls/spmv_stratus/sw/linux/app/spmv.c
@@ -10,12 +10,12 @@
 #include <test/test.h>
 #include <test/time.h>
 #include <fixed_point.h>
-#include <spmv.h>
+#include <spmv_stratus.h>
 
 #define DEVNAME "/dev/spmv_stratus.0"
 #define NAME "spmv_stratus"
 
-static const char usage_str[] = "usage: spmv coherence cmd [plm_size] [fit_plm] [in_file] [-v]\n"
+static const char usage_str[] = "usage: spmv_stratus coherence cmd [plm_size] [fit_plm] [in_file] [-v]\n"
 	"  coherence : none|llc-coh-dma|coh-dma|coh\n"
 	"  cmd       : config|test|run|hw\n"
 	"\n"
@@ -29,7 +29,7 @@ static const char usage_str[] = "usage: spmv coherence cmd [plm_size] [fit_plm] 
 
 struct spmv_test {
 	struct test_info info;
-	struct spmv_access desc;
+	struct spmv_stratus_access desc;
 
 	unsigned int nrows;
 	unsigned int ncols;
@@ -357,7 +357,7 @@ static struct spmv_test spmv_test = {
 		.diff_ok	= spmv_diff_ok,
 		.comp           = spmv_comp,
 		.esp		= &spmv_test.desc.esp,
-		.cm		= SPMV_IOC_ACCESS,
+		.cm		= SPMV_STRATUS_IOC_ACCESS,
 	},
 };
 

--- a/accelerators/stratus_hls/spmv_stratus/sw/linux/driver/Kbuild
+++ b/accelerators/stratus_hls/spmv_stratus/sw/linux/driver/Kbuild
@@ -1,3 +1,3 @@
 EXTRA_CFLAGS += \
 	     -I$(DRIVERS)/include -I$(DRIVERS)/../common/include -I$(ACC_SW)/linux/include
-obj-m := spmv.o
+obj-m := spmv_stratus.o

--- a/accelerators/stratus_hls/spmv_stratus/sw/linux/driver/spmv_stratus.c
+++ b/accelerators/stratus_hls/spmv_stratus/sw/linux/driver/spmv_stratus.c
@@ -7,7 +7,7 @@
 #include <esp_accelerator.h>
 #include <esp.h>
 
-#include "spmv.h"
+#include "spmv_stratus.h"
 
 #define DRV_NAME	"spmv_stratus"
 
@@ -18,7 +18,7 @@
 #define SPMV_VALS_PLM_SIZE_REG	0x50
 #define SPMV_VECT_FITS_PLM_REG	0x54
 
-struct spmv_device {
+struct spmv_stratus_device {
 	struct esp_device esp;
 };
 
@@ -39,14 +39,14 @@ static struct of_device_id spmv_device_ids[] = {
 
 static int spmv_devs;
 
-static inline struct spmv_device *to_spmv(struct esp_device *esp)
+static inline struct spmv_stratus_device *to_spmv(struct esp_device *esp)
 {
-	return container_of(esp, struct spmv_device, esp);
+	return container_of(esp, struct spmv_stratus_device, esp);
 }
 
 static void spmv_prep_xfer(struct esp_device *esp, void *arg)
 {
-	struct spmv_access *a = arg;
+	struct spmv_stratus_access *a = arg;
 
 	iowrite32be(a->nrows, esp->iomem + SPMV_NROWS_REG);
 	iowrite32be(a->ncols, esp->iomem + SPMV_NCOLS_REG);
@@ -58,7 +58,7 @@ static void spmv_prep_xfer(struct esp_device *esp, void *arg)
 
 static bool spmv_xfer_input_ok(struct esp_device *esp, void *arg)
 {
-	struct spmv_access *a = arg;
+	struct spmv_stratus_access *a = arg;
 	long long unsigned mtx_max = ((long long unsigned) a->nrows) * ((long long unsigned) a->ncols);
 
 	if (!is_power_of_2(a->nrows))
@@ -90,7 +90,7 @@ static bool spmv_xfer_input_ok(struct esp_device *esp, void *arg)
 
 static int spmv_probe(struct platform_device *pdev)
 {
-	struct spmv_device *spmv;
+	struct spmv_stratus_device *spmv;
 	struct esp_device *esp;
 	int rc;
 
@@ -115,7 +115,7 @@ static int spmv_probe(struct platform_device *pdev)
 static int __exit spmv_remove(struct platform_device *pdev)
 {
 	struct esp_device *esp = platform_get_drvdata(pdev);
-	struct spmv_device *spmv = to_spmv(esp);
+	struct spmv_stratus_device *spmv = to_spmv(esp);
 
 	esp_device_unregister(esp);
 	kfree(spmv);
@@ -134,8 +134,8 @@ static struct esp_driver spmv_driver = {
 	},
 	.xfer_input_ok	= spmv_xfer_input_ok,
 	.prep_xfer	= spmv_prep_xfer,
-	.ioctl_cm	= SPMV_IOC_ACCESS,
-	.arg_size	= sizeof(struct spmv_access),
+	.ioctl_cm	= SPMV_STRATUS_IOC_ACCESS,
+	.arg_size	= sizeof(struct spmv_stratus_access),
 };
 
 static int __init spmv_init(void)
@@ -155,4 +155,4 @@ MODULE_DEVICE_TABLE(of, spmv_device_ids);
 
 MODULE_AUTHOR("Emilio G. Cota <cota@braap.org>");
 MODULE_LICENSE("GPL");
-MODULE_DESCRIPTION("spmv driver");
+MODULE_DESCRIPTION("spmv_stratus driver");

--- a/accelerators/stratus_hls/spmv_stratus/sw/linux/include/spmv_stratus.h
+++ b/accelerators/stratus_hls/spmv_stratus/sw/linux/include/spmv_stratus.h
@@ -1,5 +1,5 @@
-#ifndef _SPMV_H_
-#define _SPMV_H_
+#ifndef _SPMV_STRATUS_H_
+#define _SPMV_STRATUS_H_
 
 #ifdef __KERNEL__
 #include <linux/ioctl.h>
@@ -15,7 +15,7 @@
 #include <esp.h>
 #include <esp_accelerator.h>
 
-struct spmv_access {
+struct spmv_stratus_access {
 	struct esp_access esp;
 	// Rows of input matrix. Rows of output vector.
 	// Powers of 2
@@ -37,6 +37,6 @@ struct spmv_access {
 	unsigned int vect_fits_plm;
 };
 
-#define SPMV_IOC_ACCESS	_IOW ('S', 0, struct spmv_access)
+#define SPMV_STRATUS_IOC_ACCESS	_IOW ('S', 0, struct spmv_stratus_access)
 
-#endif /* _SPMV_H_ */
+#endif /* _SPMV_STRATUS_H_ */

--- a/accelerators/stratus_hls/synth_stratus/sw/linux/driver/Kbuild
+++ b/accelerators/stratus_hls/synth_stratus/sw/linux/driver/Kbuild
@@ -1,3 +1,3 @@
 EXTRA_CFLAGS += \
 	     -I$(DRIVERS)/include -I$(DRIVERS)/../common/include -I$(ACC_SW)/linux/include
-obj-m := synth.o
+obj-m := synth_stratus.o

--- a/accelerators/stratus_hls/synth_stratus/sw/linux/driver/synth_stratus.c
+++ b/accelerators/stratus_hls/synth_stratus/sw/linux/driver/synth_stratus.c
@@ -6,7 +6,7 @@
 #include <esp_accelerator.h>
 #include <esp.h>
 
-#include "synth.h"
+#include "synth_stratus.h"
 
 #define DRV_NAME	"synth_stratus"
 
@@ -24,7 +24,7 @@
 #define SYNTH_IN_PLACE_REG		0x6c
 #define SYNTH_WR_DATA_REG       0x70
 #define SYNTH_RD_DATA_REG       0x74
-struct synth_device {
+struct synth_stratus_device {
 	struct esp_device esp;
 };
 
@@ -45,14 +45,14 @@ static struct of_device_id synth_device_ids[] = {
 
 static int synth_devs; // TODO this is never initialized
 
-static inline struct synth_device *to_synth(struct esp_device *esp)
+static inline struct synth_stratus_device *to_synth(struct esp_device *esp)
 {
-	return container_of(esp, struct synth_device, esp);
+	return container_of(esp, struct synth_stratus_device, esp);
 }
 
 static void synth_prep_xfer(struct esp_device *esp, void *arg)
 {
-	struct synth_access *a = arg;
+	struct synth_stratus_access *a = arg;
 
 	iowrite32be(a->offset, esp->iomem + SYNTH_OFFSET_REG);
 	iowrite32be(a->pattern, esp->iomem + SYNTH_PATTERN_REG);
@@ -77,7 +77,7 @@ static bool synth_xfer_input_ok(struct esp_device *esp, void *arg)
 
 static int synth_probe(struct platform_device *pdev)
 {
-	struct synth_device *synth;
+	struct synth_stratus_device *synth;
 	struct esp_device *esp;
 	int rc;
 
@@ -102,7 +102,7 @@ static int synth_probe(struct platform_device *pdev)
 static int __exit synth_remove(struct platform_device *pdev)
 {
 	struct esp_device *esp = platform_get_drvdata(pdev);
-	struct synth_device *synth = to_synth(esp);
+	struct synth_stratus_device *synth = to_synth(esp);
 
 	esp_device_unregister(esp);
 	kfree(synth);
@@ -121,8 +121,8 @@ static struct esp_driver synth_driver = {
 	},
 	.xfer_input_ok	= synth_xfer_input_ok,
 	.prep_xfer	= synth_prep_xfer,
-	.ioctl_cm	= SYNTH_IOC_ACCESS,
-	.arg_size	= sizeof(struct synth_access),
+	.ioctl_cm	= SYNTH_STRATUS_IOC_ACCESS,
+	.arg_size	= sizeof(struct synth_stratus_access),
 };
 
 static int __init synth_init(void)
@@ -142,4 +142,4 @@ MODULE_DEVICE_TABLE(of, synth_device_ids);
 
 MODULE_AUTHOR("Emilio G. Cota <cota@braap.org>");
 MODULE_LICENSE("GPL");
-MODULE_DESCRIPTION("synth driver");
+MODULE_DESCRIPTION("synth_stratus driver");

--- a/accelerators/stratus_hls/synth_stratus/sw/linux/include/synth_stratus.h
+++ b/accelerators/stratus_hls/synth_stratus/sw/linux/include/synth_stratus.h
@@ -1,5 +1,5 @@
-#ifndef _SYNTH_H_
-#define _SYNTH_H_
+#ifndef _SYNTH_STRATUS_H_
+#define _SYNTH_STRATUS_H_
 
 #ifdef __KERNEL__
 #include <linux/ioctl.h>
@@ -17,7 +17,7 @@
 
 enum synth_pattern {PATTERN_STREAMING = 0, PATTERN_STRIDED, PATTERN_IRREGULAR};
 
-struct synth_access {
+struct synth_stratus_access {
 	struct esp_access esp;
     unsigned int offset;                    /* Memory offset when chaining dependent accelerators */
     enum synth_pattern pattern;             /* load pattern: streaming, strided, irregular */
@@ -39,6 +39,6 @@ struct synth_access {
 
 enum alloc_effort {ALLOC_NONE, ALLOC_AUTO};
 
-#define SYNTH_IOC_ACCESS	_IOW ('S', 0, struct synth_access)
+#define SYNTH_STRATUS_IOC_ACCESS	_IOW ('S', 0, struct synth_stratus_access)
 
-#endif /* _SYNTH_H_ */
+#endif /* _SYNTH_STRATUS_H_ */

--- a/accelerators/stratus_hls/vitbfly2_stratus/sw/linux/app/viterbi_decoder_generic.c
+++ b/accelerators/stratus_hls/vitbfly2_stratus/sw/linux/app/viterbi_decoder_generic.c
@@ -40,7 +40,7 @@
 #include <unistd.h>
 
 #include "contig.h"
-#include "vitbfly2.h"
+#include "vitbfly2_stratus.h"
 
 #include "viterbi_decoder_generic.h"
 #include "viterbi_standalone.h"
@@ -179,14 +179,14 @@ uint8_t* depuncture(uint8_t *in) {
 
 #define DEVNAME	"/dev/vitbfly2_stratus.0"
 
-static void viterbi_butterfly2_hw(unsigned char *inMemory, int *fd, contig_handle_t *mem, size_t size, size_t out_size, struct vitbfly2_access *desc)
+static void viterbi_butterfly2_hw(unsigned char *inMemory, int *fd, contig_handle_t *mem, size_t size, size_t out_size, struct vitbfly2_stratus_access *desc)
 {
 
 
 	contig_copy_to(*mem, 0, inMemory, size);
 
 
-	if (ioctl(*fd, VITBFLY2_IOC_ACCESS, *desc)) {
+	if (ioctl(*fd, VITBFLY2_STRATUS_IOC_ACCESS, *desc)) {
 		perror("IOCTL:");
 		exit(EXIT_FAILURE);
 	}
@@ -436,7 +436,7 @@ uint8_t* decode(ofdm_param *ofdm, frame_param *frame, uint8_t *in) {
   contig_handle_t mem;
   const size_t size = 6 * 64 * sizeof(unsigned char);
   const size_t out_size = 4 * 64 * sizeof(unsigned char);
-  struct vitbfly2_access desc;
+  struct vitbfly2_stratus_access desc;
   unsigned invocations = 0;
 
   printf("Open device %s\n", DEVNAME);

--- a/accelerators/stratus_hls/vitbfly2_stratus/sw/linux/driver/Kbuild
+++ b/accelerators/stratus_hls/vitbfly2_stratus/sw/linux/driver/Kbuild
@@ -1,3 +1,3 @@
 EXTRA_CFLAGS += \
 	     -I$(DRIVERS)/include -I$(DRIVERS)/../common/include -I$(ACC_SW)/linux/include
-obj-m := vitbfly2.o
+obj-m := vitbfly2_stratus.o

--- a/accelerators/stratus_hls/vitbfly2_stratus/sw/linux/driver/vitbfly2_stratus.c
+++ b/accelerators/stratus_hls/vitbfly2_stratus/sw/linux/driver/vitbfly2_stratus.c
@@ -7,11 +7,11 @@
 #include <esp_accelerator.h>
 #include <esp.h>
 
-#include "vitbfly2.h"
+#include "vitbfly2_stratus.h"
 
 #define DRV_NAME	"vitbfly2_stratus"
 
-struct vitbfly2_device {
+struct vitbfly2_stratus_device {
 	struct esp_device esp;
 };
 
@@ -32,9 +32,9 @@ static struct of_device_id vitbfly2_device_ids[] = {
 
 static int vitbfly2_devs;
 
-static inline struct vitbfly2_device *to_vitbfly2(struct esp_device *esp)
+static inline struct vitbfly2_stratus_device *to_vitbfly2(struct esp_device *esp)
 {
-	return container_of(esp, struct vitbfly2_device, esp);
+	return container_of(esp, struct vitbfly2_stratus_device, esp);
 }
 
 static void vitbfly2_prep_xfer(struct esp_device *esp, void *arg)
@@ -48,7 +48,7 @@ static bool vitbfly2_xfer_input_ok(struct esp_device *esp, void *arg)
 
 static int vitbfly2_probe(struct platform_device *pdev)
 {
-	struct vitbfly2_device *vitbfly2;
+	struct vitbfly2_stratus_device *vitbfly2;
 	struct esp_device *esp;
 	int rc;
 
@@ -73,7 +73,7 @@ static int vitbfly2_probe(struct platform_device *pdev)
 static int __exit vitbfly2_remove(struct platform_device *pdev)
 {
 	struct esp_device *esp = platform_get_drvdata(pdev);
-	struct vitbfly2_device *vitbfly2 = to_vitbfly2(esp);
+	struct vitbfly2_stratus_device *vitbfly2 = to_vitbfly2(esp);
 
 	esp_device_unregister(esp);
 	kfree(vitbfly2);
@@ -92,8 +92,8 @@ static struct esp_driver vitbfly2_driver = {
 	},
 	.xfer_input_ok	= vitbfly2_xfer_input_ok,
 	.prep_xfer	= vitbfly2_prep_xfer,
-	.ioctl_cm	= VITBFLY2_IOC_ACCESS,
-	.arg_size	= sizeof(struct vitbfly2_access),
+	.ioctl_cm	= VITBFLY2_STRATUS_IOC_ACCESS,
+	.arg_size	= sizeof(struct vitbfly2_stratus_access),
 };
 
 static int __init vitbfly2_init(void)
@@ -113,4 +113,4 @@ MODULE_DEVICE_TABLE(of, vitbfly2_device_ids);
 
 MODULE_AUTHOR("Emilio G. Cota <cota@braap.org>");
 MODULE_LICENSE("GPL");
-MODULE_DESCRIPTION("vitbfly2 driver");
+MODULE_DESCRIPTION("vitbfly2_stratus driver");

--- a/accelerators/stratus_hls/vitbfly2_stratus/sw/linux/include/vitbfly2_stratus.h
+++ b/accelerators/stratus_hls/vitbfly2_stratus/sw/linux/include/vitbfly2_stratus.h
@@ -1,5 +1,5 @@
-#ifndef _ADDER_H_
-#define _ADDER_H_
+#ifndef _VITBFLY2_STRATUS_H_
+#define _VITBFLY2_STRATUS_H_
 
 #ifdef __KERNEL__
 #include <linux/ioctl.h>
@@ -15,11 +15,10 @@
 #include <esp.h>
 #include <esp_accelerator.h>
 
-struct adder_access {
+struct vitbfly2_stratus_access {
 	struct esp_access esp;
-	unsigned int nbursts;
 };
 
-#define ADDER_IOC_ACCESS _IOW ('S', 0, struct adder_access)
+#define VITBFLY2_STRATUS_IOC_ACCESS	_IOW ('S', 0, struct vitbfly2_stratus_access)
 
-#endif /* _ADDER_H_ */
+#endif /* _VITBFLY2_STRATUS_H_ */

--- a/accelerators/stratus_hls/vitdodec_stratus/sw/linux/app/cfg.h
+++ b/accelerators/stratus_hls/vitdodec_stratus/sw/linux/app/cfg.h
@@ -2,7 +2,7 @@
 #define __ESP_CFG_000_H__
 
 #include "libesp.h"
-#include "vitdodec.h"
+#include "vitdodec_stratus.h"
 
 typedef int8_t token_t;
 
@@ -18,7 +18,7 @@ const int32_t data_bits = DATA_BITS;
 
 #define NACC 1
 
-struct vitdodec_access vitdodec_cfg_000[] = {
+struct vitdodec_stratus_access vitdodec_cfg_000[] = {
 	{
 		/* <<--descriptor-->> */
 		.cbps = CBPS,
@@ -37,7 +37,7 @@ esp_thread_info_t cfg_000[] = {
 	{
 		.run = true,
 		.devname = "vitdodec_stratus.0",
-		.ioctl_req = VITDODEC_IOC_ACCESS,
+		.ioctl_req = VITDODEC_STRATUS_IOC_ACCESS,
 		.esp_desc = &(vitdodec_cfg_000[0].esp),
 	}
 };

--- a/accelerators/stratus_hls/vitdodec_stratus/sw/linux/driver/Kbuild
+++ b/accelerators/stratus_hls/vitdodec_stratus/sw/linux/driver/Kbuild
@@ -1,3 +1,3 @@
 EXTRA_CFLAGS += \
 	     -I$(DRIVERS)/include -I$(DRIVERS)/../common/include -I$(ACC_SW)/linux/include
-obj-m := vitdodec.o
+obj-m := vitdodec_stratus.o

--- a/accelerators/stratus_hls/vitdodec_stratus/sw/linux/driver/vitdodec_stratus.c
+++ b/accelerators/stratus_hls/vitdodec_stratus/sw/linux/driver/vitdodec_stratus.c
@@ -6,7 +6,7 @@
 #include <esp_accelerator.h>
 #include <esp.h>
 
-#include "vitdodec.h"
+#include "vitdodec_stratus.h"
 
 #define DRV_NAME	"vitdodec_stratus"
 
@@ -15,7 +15,7 @@
 #define VITDODEC_NTRACEBACK_REG 0x44
 #define VITDODEC_DATA_BITS_REG 0x40
 
-struct vitdodec_device {
+struct vitdodec_stratus_device {
 	struct esp_device esp;
 };
 
@@ -36,14 +36,14 @@ static struct of_device_id vitdodec_device_ids[] = {
 
 static int vitdodec_devs;
 
-static inline struct vitdodec_device *to_vitdodec(struct esp_device *esp)
+static inline struct vitdodec_stratus_device *to_vitdodec(struct esp_device *esp)
 {
-	return container_of(esp, struct vitdodec_device, esp);
+	return container_of(esp, struct vitdodec_stratus_device, esp);
 }
 
 static void vitdodec_prep_xfer(struct esp_device *esp, void *arg)
 {
-	struct vitdodec_access *a = arg;
+	struct vitdodec_stratus_access *a = arg;
 
 	/* <<--regs-config-->> */
 	iowrite32be(a->cbps, esp->iomem + VITDODEC_CBPS_REG);
@@ -56,15 +56,15 @@ static void vitdodec_prep_xfer(struct esp_device *esp, void *arg)
 
 static bool vitdodec_xfer_input_ok(struct esp_device *esp, void *arg)
 {
-	/* struct vitdodec_device *vitdodec = to_vitdodec(esp); */
-	/* struct vitdodec_access *a = arg; */
+	/* struct vitdodec_stratus_device *vitdodec = to_vitdodec(esp); */
+	/* struct vitdodec_stratus_access *a = arg; */
 
 	return true;
 }
 
 static int vitdodec_probe(struct platform_device *pdev)
 {
-	struct vitdodec_device *vitdodec;
+	struct vitdodec_stratus_device *vitdodec;
 	struct esp_device *esp;
 	int rc;
 
@@ -89,7 +89,7 @@ static int vitdodec_probe(struct platform_device *pdev)
 static int __exit vitdodec_remove(struct platform_device *pdev)
 {
 	struct esp_device *esp = platform_get_drvdata(pdev);
-	struct vitdodec_device *vitdodec = to_vitdodec(esp);
+	struct vitdodec_stratus_device *vitdodec = to_vitdodec(esp);
 
 	esp_device_unregister(esp);
 	kfree(vitdodec);
@@ -108,8 +108,8 @@ static struct esp_driver vitdodec_driver = {
 	},
 	.xfer_input_ok	= vitdodec_xfer_input_ok,
 	.prep_xfer	= vitdodec_prep_xfer,
-	.ioctl_cm	= VITDODEC_IOC_ACCESS,
-	.arg_size	= sizeof(struct vitdodec_access),
+	.ioctl_cm	= VITDODEC_STRATUS_IOC_ACCESS,
+	.arg_size	= sizeof(struct vitdodec_stratus_access),
 };
 
 static int __init vitdodec_init(void)
@@ -129,4 +129,4 @@ MODULE_DEVICE_TABLE(of, vitdodec_device_ids);
 
 MODULE_AUTHOR("Emilio G. Cota <cota@braap.org>");
 MODULE_LICENSE("GPL");
-MODULE_DESCRIPTION("vitdodec driver");
+MODULE_DESCRIPTION("vitdodec_stratus driver");

--- a/accelerators/stratus_hls/vitdodec_stratus/sw/linux/include/vitdodec_stratus.h
+++ b/accelerators/stratus_hls/vitdodec_stratus/sw/linux/include/vitdodec_stratus.h
@@ -1,5 +1,5 @@
-#ifndef _<ACCELERATOR_NAME>_H_
-#define _<ACCELERATOR_NAME>_H_
+#ifndef _VITDODEC_STRATUS_H_
+#define _VITDODEC_STRATUS_H_
 
 #ifdef __KERNEL__
 #include <linux/ioctl.h>
@@ -15,13 +15,16 @@
 #include <esp.h>
 #include <esp_accelerator.h>
 
-struct <accelerator_name>_access {
+struct vitdodec_stratus_access {
 	struct esp_access esp;
 	/* <<--regs-->> */
+	unsigned cbps;
+	unsigned ntraceback;
+	unsigned data_bits;
 	unsigned src_offset;
 	unsigned dst_offset;
 };
 
-#define <ACCELERATOR_NAME>_IOC_ACCESS	_IOW ('S', 0, struct <accelerator_name>_access)
+#define VITDODEC_STRATUS_IOC_ACCESS	_IOW ('S', 0, struct vitdodec_stratus_access)
 
-#endif /* _<ACCELERATOR_NAME>_H_ */
+#endif /* _VITDODEC_STRATUS_H_ */

--- a/accelerators/vivado_hls/adder_vivado/sw/linux/app/adder.c
+++ b/accelerators/vivado_hls/adder_vivado/sw/linux/app/adder.c
@@ -8,7 +8,7 @@
 #include <my_stringify.h>
 #include <test/test.h>
 #include <test/time.h>
-#include <adder.h>
+#include <adder_vivado.h>
 
 #define DEVNAME "/dev/adder_vivado.0"
 #define NAME "adder_vivado"
@@ -79,7 +79,7 @@ typedef int32_t word_t;
 
 
 static const char usage_str[] =
-	"usage: ./adder.exe coherence [size] [-v]\n"
+	"usage: ./adder_vivado.exe coherence [size] [-v]\n"
 	"  coherence: non-coh-dma|llc-coh-dma|coh-dma|coh\n"
 	"\n"
 	"Optional arguments:.\n"
@@ -90,7 +90,7 @@ static const char usage_str[] =
 
 struct adder_test {
 	struct test_info info;
-	struct adder_access desc;
+	struct adder_vivado_access desc;
 	unsigned int nbursts;
         word_t *hbuf;
 	word_t *sbuf;
@@ -232,7 +232,7 @@ static struct adder_test adder_test = {
 		.comp		= adder_comp,
 		.diff_ok	= adder_diff_ok,
 		.esp		= &adder_test.desc.esp,
-		.cm		= ADDER_IOC_ACCESS,
+		.cm		= ADDER_VIVADO_IOC_ACCESS,
 	},
 };
 

--- a/accelerators/vivado_hls/adder_vivado/sw/linux/driver/Kbuild
+++ b/accelerators/vivado_hls/adder_vivado/sw/linux/driver/Kbuild
@@ -1,3 +1,3 @@
 EXTRA_CFLAGS += \
 	     -I$(DRIVERS)/include -I$(DRIVERS)/../common/include -I$(ACC_SW)/linux/include
-obj-m := adder.o
+obj-m := adder_vivado.o

--- a/accelerators/vivado_hls/adder_vivado/sw/linux/driver/adder_vivado.c
+++ b/accelerators/vivado_hls/adder_vivado/sw/linux/driver/adder_vivado.c
@@ -1,21 +1,19 @@
 #include <linux/of_device.h>
 #include <linux/mm.h>
+#include <linux/log2.h>
 
 #include <asm/io.h>
 
 #include <esp_accelerator.h>
 #include <esp.h>
 
-#include "adder.h"
+#include "adder_vivado.h"
 
-#define DRV_NAME	"adder_chisel"
+#define DRV_NAME	"adder_vivado"
 
-/* <<--regs-->> */
-#define ADDER_WRITEADDR_REG 0x48
-#define ADDER_SIZE_REG 0x44
-#define ADDER_READADDR_REG 0x40
+#define ADDER_NBURSTS_REG 0x40
 
-struct adder_device {
+struct adder_vivado_device {
 	struct esp_device esp;
 };
 
@@ -23,49 +21,39 @@ static struct esp_driver adder_driver;
 
 static struct of_device_id adder_device_ids[] = {
 	{
-		.name = "SLD_ADDER_CHISEL",
+		.name = "SLD_ADDER_VIVADO",
 	},
 	{
-		.name = "eb_013",
+		.name = "eb_040",
 	},
 	{
-		.compatible = "sld,adder_chisel",
+		.compatible = "sld,adder_vivado",
 	},
 	{ },
 };
 
 static int adder_devs;
 
-static inline struct adder_device *to_adder(struct esp_device *esp)
+static inline struct adder_vivado_device *to_adder(struct esp_device *esp)
 {
-	return container_of(esp, struct adder_device, esp);
+	return container_of(esp, struct adder_vivado_device, esp);
 }
 
 static void adder_prep_xfer(struct esp_device *esp, void *arg)
 {
-	struct adder_access *a = arg;
+	struct adder_vivado_access *a = arg;
 
-	/* <<--regs-config-->> */
-	iowrite32be(a->readAddr, esp->iomem + ADDER_READADDR_REG);
-	iowrite32be(a->size, esp->iomem + ADDER_SIZE_REG);
-	iowrite32be(a->writeAddr, esp->iomem + ADDER_WRITEADDR_REG);
-
-	iowrite32be(a->src_offset, esp->iomem + SRC_OFFSET_REG);
-	iowrite32be(a->dst_offset, esp->iomem + DST_OFFSET_REG);
-
+	iowrite32be(a->nbursts, esp->iomem + ADDER_NBURSTS_REG);
 }
 
 static bool adder_xfer_input_ok(struct esp_device *esp, void *arg)
 {
-	/* struct adder_device *adder = to_adder(esp); */
-	/* struct adder_access *a = arg; */
-
 	return true;
 }
 
 static int adder_probe(struct platform_device *pdev)
 {
-	struct adder_device *adder;
+	struct adder_vivado_device *adder;
 	struct esp_device *esp;
 	int rc;
 
@@ -90,7 +78,7 @@ static int adder_probe(struct platform_device *pdev)
 static int __exit adder_remove(struct platform_device *pdev)
 {
 	struct esp_device *esp = platform_get_drvdata(pdev);
-	struct adder_device *adder = to_adder(esp);
+	struct adder_vivado_device *adder = to_adder(esp);
 
 	esp_device_unregister(esp);
 	kfree(adder);
@@ -109,8 +97,8 @@ static struct esp_driver adder_driver = {
 	},
 	.xfer_input_ok	= adder_xfer_input_ok,
 	.prep_xfer	= adder_prep_xfer,
-	.ioctl_cm	= ADDER_IOC_ACCESS,
-	.arg_size	= sizeof(struct adder_access),
+	.ioctl_cm	= ADDER_VIVADO_IOC_ACCESS,
+	.arg_size	= sizeof(struct adder_vivado_access),
 };
 
 static int __init adder_init(void)
@@ -130,4 +118,4 @@ MODULE_DEVICE_TABLE(of, adder_device_ids);
 
 MODULE_AUTHOR("Emilio G. Cota <cota@braap.org>");
 MODULE_LICENSE("GPL");
-MODULE_DESCRIPTION("adder driver");
+MODULE_DESCRIPTION("adder_vivado driver");

--- a/accelerators/vivado_hls/adder_vivado/sw/linux/include/adder_vivado.h
+++ b/accelerators/vivado_hls/adder_vivado/sw/linux/include/adder_vivado.h
@@ -1,5 +1,5 @@
-#ifndef _VITBFLY2_H_
-#define _VITBFLY2_H_
+#ifndef _ADDER_VIVADO_H_
+#define _ADDER_VIVADO_H_
 
 #ifdef __KERNEL__
 #include <linux/ioctl.h>
@@ -15,10 +15,11 @@
 #include <esp.h>
 #include <esp_accelerator.h>
 
-struct vitbfly2_access {
+struct adder_vivado_access {
 	struct esp_access esp;
+	unsigned int nbursts;
 };
 
-#define VITBFLY2_IOC_ACCESS	_IOW ('S', 0, struct vitbfly2_access)
+#define ADDER_VIVADO_IOC_ACCESS _IOW ('S', 0, struct adder_vivado_access)
 
-#endif /* _VITBFLY2_H_ */
+#endif /* _ADDER_VIVADO_H_ */

--- a/soft/common/apps/examples/multifft/Makefile
+++ b/soft/common/apps/examples/multifft/Makefile
@@ -1,0 +1,3 @@
+EXTRA_CFLAGS ?=
+APPNAME := multifft
+include $(DRIVERS)/common.mk

--- a/soft/common/apps/examples/multifft/multifft.c
+++ b/soft/common/apps/examples/multifft/multifft.c
@@ -208,10 +208,10 @@ int main(int argc, char **argv)
 	printf("  ** Press ENTER to START ** ");
 	scanf("%c", &key);
 
-    for (k = 0; k < NACC; k++)
-	    cfg_parallel[k].hw_buf = buf;
+	for (k = 0; k < NACC; k++)
+		cfg_parallel[k].hw_buf = buf;
 
-    esp_run(cfg_parallel, NACC);
+	esp_run(cfg_parallel, NACC);
 
 	printf("\n  ** DONE **\n");
 
@@ -236,8 +236,9 @@ int main(int argc, char **argv)
 	printf("  ** Press ENTER to START ** ");
 	scanf("%c", &key);
 
-    for (k = 0; k < NACC; k++)
-        cfg_p2p[k].hw_buf = buf;
+	for (k = 0; k < NACC; k++)
+		cfg_p2p[k].hw_buf = buf;
+
 	esp_run(cfg_p2p, NACC);
 
 	printf("\n  ** DONE **\n");

--- a/soft/common/drivers/linux/common.mk
+++ b/soft/common/drivers/linux/common.mk
@@ -8,6 +8,8 @@ ARCH ?= sparc
 CFLAGS += -fno-builtin-cos -fno-builtin-sin
 endif
 
+BUILD_DRIVERS ?= $(BUILD_PATH)/../../..
+
 SRCS := $(wildcard *.c)
 HEADERS := $(wildcard *.h) $(wildcard $(DRIVERS)/include/*.h)
 HEADERS += $(wildcard $(DRIVERS)/../common/include/*.h) $(wildcard ../include/*.h)
@@ -26,8 +28,8 @@ CFLAGS += $(EXTRA_CFLAGS)
 CFLAGS += -O3
 CFLAGS += -Wall
 CFLAGS += -I$(DRIVERS)/include -I$(DRIVERS)/../common/include -I../include
-CFLAGS += -L$(BUILD_PATH)/../../../contig_alloc -L$(BUILD_PATH)/../../../test
-CFLAGS += -L$(BUILD_PATH)/../../../libesp -L$(BUILD_PATH)/../../../utils/linux
+CFLAGS += -L$(BUILD_DRIVERS)/contig_alloc -L$(BUILD_DRIVERS)/test
+CFLAGS += -L$(BUILD_DRIVERS)/libesp -L$(BUILD_DRIVERS)/utils/linux
 LDFLAGS += -lm -lrt -lpthread -lesp -ltest -lcontig -lutils
 
 CC := $(CROSS_COMPILE)gcc
@@ -37,18 +39,18 @@ all: $(OBJS) $(EXES) $(EXE) $(BINS) $(BIN)
 
 ifneq ($(APPNAME),)
 $(BUILD_PATH)/%.o: %.c $(HEADERS)
-	CROSS_COMPILE=$(CROSS_COMPILE) DRIVERS=$(DRIVERS) $(MAKE) -C $(BUILD_PATH)/../../../contig_alloc/ libcontig.a
-	CROSS_COMPILE=$(CROSS_COMPILE) BUILD_PATH=$(BUILD_PATH)/../../../test $(MAKE) -C $(DRIVERS)/test
-	CROSS_COMPILE=$(CROSS_COMPILE) BUILD_PATH=$(BUILD_PATH)/../../../libesp $(MAKE) -C $(DRIVERS)/libesp
-	CROSS_COMPILE=$(CROSS_COMPILE) BUILD_PATH=$(BUILD_PATH)/../../../utils/linux $(MAKE) -C $(DRIVERS)/utils
+	CROSS_COMPILE=$(CROSS_COMPILE) DRIVERS=$(DRIVERS) $(MAKE) -C $(BUILD_DRIVERS)/contig_alloc/ libcontig.a
+	CROSS_COMPILE=$(CROSS_COMPILE) BUILD_PATH=$(BUILD_DRIVERS)/test $(MAKE) -C $(DRIVERS)/test
+	CROSS_COMPILE=$(CROSS_COMPILE) BUILD_PATH=$(BUILD_DRIVERS)/libesp $(MAKE) -C $(DRIVERS)/libesp
+	CROSS_COMPILE=$(CROSS_COMPILE) BUILD_PATH=$(BUILD_DRIVERS)/utils/linux $(MAKE) -C $(DRIVERS)/utils
 	$(CC) $(CFLAGS) -c $< -o $@ $(LDFLAGS)
 endif
 
 $(BUILD_PATH)/%.exe: %.c $(OBJS) $(HEADERS)
-	CROSS_COMPILE=$(CROSS_COMPILE) DRIVERS=$(DRIVERS) $(MAKE) -C $(BUILD_PATH)/../../../contig_alloc/ libcontig.a
-	CROSS_COMPILE=$(CROSS_COMPILE) BUILD_PATH=$(BUILD_PATH)/../../../test $(MAKE) -C $(DRIVERS)/test
-	CROSS_COMPILE=$(CROSS_COMPILE) BUILD_PATH=$(BUILD_PATH)/../../../libesp $(MAKE) -C $(DRIVERS)/libesp
-	CROSS_COMPILE=$(CROSS_COMPILE) BUILD_PATH=$(BUILD_PATH)/../../../utils/linux $(MAKE) -C $(DRIVERS)/utils
+	CROSS_COMPILE=$(CROSS_COMPILE) DRIVERS=$(DRIVERS) $(MAKE) -C $(BUILD_DRIVERS)/contig_alloc/ libcontig.a
+	CROSS_COMPILE=$(CROSS_COMPILE) BUILD_PATH=$(BUILD_DRIVERS)/test $(MAKE) -C $(DRIVERS)/test
+	CROSS_COMPILE=$(CROSS_COMPILE) BUILD_PATH=$(BUILD_DRIVERS)/libesp $(MAKE) -C $(DRIVERS)/libesp
+	CROSS_COMPILE=$(CROSS_COMPILE) BUILD_PATH=$(BUILD_DRIVERS)/utils/linux $(MAKE) -C $(DRIVERS)/utils
 	$(CC) $(CFLAGS) -o $@ $< $(OBJS) $(LDFLAGS)
 
 clean:

--- a/tools/accgen/accgen.sh
+++ b/tools/accgen/accgen.sh
@@ -310,10 +310,13 @@ for d in $dirs; do
 
     if cat /etc/os-release | grep -q -i ubuntu; then
         rename "s/accelerator/$LOWER/g" *
+	rename "s/acc_full/$LOWERFULL/g" *
     elif cat /etc/os-release | grep -q -i centos; then
         rename accelerator $LOWER *
+	rename acc_full $LOWERFULL *
     elif cat /etc/os-release | grep -q -i rhel; then
         rename accelerator $LOWER *
+	rename acc_full $LOWERFULL *
     fi
 
     sed -i "s/<accelerator_name>/$LOWER/g" *
@@ -579,10 +582,13 @@ for d in $dirs; do
 
     if cat /etc/os-release | grep -q -i ubuntu; then
         rename "s/accelerator/$LOWER/g" *
+	rename "s/acc_full/$LOWERFULL/g" *
     elif cat /etc/os-release | grep -q -i centos; then
 	rename accelerator $LOWER *
+	rename acc_full $LOWERFULL *
     elif cat /etc/os-release | grep -q -i rhel; then
 	rename accelerator $LOWER *
+	rename acc_full $LOWERFULL *
     fi
 
     sed -i "s/<accelerator_name>/$LOWER/g" *
@@ -595,13 +601,13 @@ done
 cd $SOFT_DIR/linux/include
 indent="\	"
 for key in ${!values[@]}; do
-    sed -i "/\/\* <<--regs-->> \*\//a ${indent}unsigned ${key};" ${LOWER}.h
+    sed -i "/\/\* <<--regs-->> \*\//a ${indent}unsigned ${key};" ${LOWERFULL}.h
 done
 
 ## Linux and baremetal drivers
 cd $SOFT_DIR
 indent="\	"
-sed -i "s/\/\* <<--id-->> \*\//${ID}/g" linux/driver/${LOWER}.c
+sed -i "s/\/\* <<--id-->> \*\//${ID}/g" linux/driver/${LOWERFULL}.c
 
 user_reg_offset=64
 for key in ${!values[@]}; do
@@ -609,10 +615,10 @@ for key in ${!values[@]}; do
     reg_offset_hex=$(printf '%x\n' ${user_reg_offset})
     register_name="${UPPER}_${key_upper}_REG"
 
-    for f in "linux/driver/${LOWER}.c baremetal/${LOWER}.c"; do
+    for f in "linux/driver/${LOWERFULL}.c baremetal/${LOWER}.c"; do
 	sed -i "/\/\* <<--regs-->> \*\//a #define ${register_name} 0x${reg_offset_hex}" ${f}
     done
-    sed -i "/\/\* <<--regs-config-->> \*\//a ${indent}iowrite32be(a->${key}, esp->iomem + ${register_name});" linux/driver/${LOWER}.c
+    sed -i "/\/\* <<--regs-config-->> \*\//a ${indent}iowrite32be(a->${key}, esp->iomem + ${register_name});" linux/driver/${LOWERFULL}.c
     sed -i "/\/\* <<--regs-config-->> \*\//a ${indent}${indent}iowrite32(dev, ${register_name}, ${key});" baremetal/${LOWER}.c
     user_reg_offset=$((user_reg_offset + 4))
 done

--- a/tools/accgen/templates/drivers/linux/app/cfg.h
+++ b/tools/accgen/templates/drivers/linux/app/cfg.h
@@ -2,7 +2,7 @@
 #define __ESP_CFG_000_H__
 
 #include "libesp.h"
-#include "<accelerator_name>.h"
+#include "<acc_full_name>.h"
 
 typedef /* <<--token-type-->> */ token_t;
 
@@ -12,7 +12,7 @@ typedef /* <<--token-type-->> */ token_t;
 
 #define NACC 1
 
-struct <accelerator_name>_access <accelerator_name>_cfg_000[] = {
+struct <acc_full_name>_access <accelerator_name>_cfg_000[] = {
 	{
 		/* <<--descriptor-->> */
 		.src_offset = 0,
@@ -28,7 +28,7 @@ esp_thread_info_t cfg_000[] = {
 	{
 		.run = true,
 		.devname = "<acc_full_name>.0",
-		.ioctl_req = <ACCELERATOR_NAME>_IOC_ACCESS,
+		.ioctl_req = <ACC_FULL_NAME>_IOC_ACCESS,
 		.esp_desc = &(<accelerator_name>_cfg_000[0].esp),
 	}
 };

--- a/tools/accgen/templates/drivers/linux/driver/Kbuild
+++ b/tools/accgen/templates/drivers/linux/driver/Kbuild
@@ -1,3 +1,3 @@
 EXTRA_CFLAGS += \
              -I$(DRIVERS)/include -I$(DRIVERS)/../common/include -I$(ACC_SW)/linux/include
-obj-m := <accelerator_name>.o
+obj-m := <acc_full_name>.o

--- a/tools/accgen/templates/drivers/linux/driver/acc_full.c
+++ b/tools/accgen/templates/drivers/linux/driver/acc_full.c
@@ -6,13 +6,13 @@
 #include <esp_accelerator.h>
 #include <esp.h>
 
-#include "<accelerator_name>.h"
+#include "<acc_full_name>.h"
 
 #define DRV_NAME	"<acc_full_name>"
 
 /* <<--regs-->> */
 
-struct <accelerator_name>_device {
+struct <acc_full_name>_device {
 	struct esp_device esp;
 };
 
@@ -33,14 +33,14 @@ static struct of_device_id <accelerator_name>_device_ids[] = {
 
 static int <accelerator_name>_devs;
 
-static inline struct <accelerator_name>_device *to_<accelerator_name>(struct esp_device *esp)
+static inline struct <acc_full_name>_device *to_<accelerator_name>(struct esp_device *esp)
 {
-	return container_of(esp, struct <accelerator_name>_device, esp);
+	return container_of(esp, struct <acc_full_name>_device, esp);
 }
 
 static void <accelerator_name>_prep_xfer(struct esp_device *esp, void *arg)
 {
-	struct <accelerator_name>_access *a = arg;
+	struct <acc_full_name>_access *a = arg;
 
 	/* <<--regs-config-->> */
 	iowrite32be(a->src_offset, esp->iomem + SRC_OFFSET_REG);
@@ -50,15 +50,15 @@ static void <accelerator_name>_prep_xfer(struct esp_device *esp, void *arg)
 
 static bool <accelerator_name>_xfer_input_ok(struct esp_device *esp, void *arg)
 {
-	/* struct <accelerator_name>_device *<accelerator_name> = to_<accelerator_name>(esp); */
-	/* struct <accelerator_name>_access *a = arg; */
+	/* struct <acc_full_name>_device *<accelerator_name> = to_<accelerator_name>(esp); */
+	/* struct <acc_full_name>_access *a = arg; */
 
 	return true;
 }
 
 static int <accelerator_name>_probe(struct platform_device *pdev)
 {
-	struct <accelerator_name>_device *<accelerator_name>;
+	struct <acc_full_name>_device *<accelerator_name>;
 	struct esp_device *esp;
 	int rc;
 
@@ -83,7 +83,7 @@ static int <accelerator_name>_probe(struct platform_device *pdev)
 static int __exit <accelerator_name>_remove(struct platform_device *pdev)
 {
 	struct esp_device *esp = platform_get_drvdata(pdev);
-	struct <accelerator_name>_device *<accelerator_name> = to_<accelerator_name>(esp);
+	struct <acc_full_name>_device *<accelerator_name> = to_<accelerator_name>(esp);
 
 	esp_device_unregister(esp);
 	kfree(<accelerator_name>);
@@ -102,8 +102,8 @@ static struct esp_driver <accelerator_name>_driver = {
 	},
 	.xfer_input_ok	= <accelerator_name>_xfer_input_ok,
 	.prep_xfer	= <accelerator_name>_prep_xfer,
-	.ioctl_cm	= <ACCELERATOR_NAME>_IOC_ACCESS,
-	.arg_size	= sizeof(struct <accelerator_name>_access),
+	.ioctl_cm	= <ACC_FULL_NAME>_IOC_ACCESS,
+	.arg_size	= sizeof(struct <acc_full_name>_access),
 };
 
 static int __init <accelerator_name>_init(void)
@@ -123,4 +123,4 @@ MODULE_DEVICE_TABLE(of, <accelerator_name>_device_ids);
 
 MODULE_AUTHOR("Emilio G. Cota <cota@braap.org>");
 MODULE_LICENSE("GPL");
-MODULE_DESCRIPTION("<accelerator_name> driver");
+MODULE_DESCRIPTION("<acc_full_name> driver");

--- a/tools/accgen/templates/drivers/linux/include/acc_full.h
+++ b/tools/accgen/templates/drivers/linux/include/acc_full.h
@@ -1,5 +1,5 @@
-#ifndef _FFT_H_
-#define _FFT_H_
+#ifndef _<ACC_FULL_NAME>_H_
+#define _<ACC_FULL_NAME>_H_
 
 #ifdef __KERNEL__
 #include <linux/ioctl.h>
@@ -15,14 +15,13 @@
 #include <esp.h>
 #include <esp_accelerator.h>
 
-struct fft_access {
+struct <acc_full_name>_access {
 	struct esp_access esp;
 	/* <<--regs-->> */
-	unsigned stride;
 	unsigned src_offset;
 	unsigned dst_offset;
 };
 
-#define FFT_IOC_ACCESS	_IOW ('S', 0, struct fft_access)
+#define <ACC_FULL_NAME>_IOC_ACCESS	_IOW ('S', 0, struct <acc_full_name>_access)
 
-#endif /* _FFT_H_ */
+#endif /* _<ACC_FULL_NAME>_H_ */

--- a/tools/accgen/templates/drivers_hls4ml/linux/app/cfg.h
+++ b/tools/accgen/templates/drivers_hls4ml/linux/app/cfg.h
@@ -2,7 +2,7 @@
 #define __ESP_CFG_000_H__
 
 #include "libesp.h"
-#include "<accelerator_name>.h"
+#include "<acc_full_name>.h"
 
 typedef /* <<--token-type-->> */ token_t;
 
@@ -15,7 +15,7 @@ typedef /* <<--token-type-->> */ token_t;
 #define INT_BITS /* <<--int_bits-->> */
 #define fl2fx(A) float_to_fixed/* <<--data_width-->> */(A, INT_BITS)
 
-struct <accelerator_name>_access <accelerator_name>_cfg_000[] = {
+struct <acc_full_name>_access <accelerator_name>_cfg_000[] = {
 	{
 		/* <<--descriptor-->> */
 		.src_offset = 0,
@@ -31,7 +31,7 @@ esp_thread_info_t cfg_000[] = {
 	{
 		.run = true,
 		.devname = "<acc_full_name>.0",
-		.ioctl_req = <ACCELERATOR_NAME>_IOC_ACCESS,
+		.ioctl_req = <ACC_FULL_NAME>_IOC_ACCESS,
 		.esp_desc = &(<accelerator_name>_cfg_000[0].esp),
 	}
 };

--- a/tools/espmon/espmon.pro
+++ b/tools/espmon/espmon.pro
@@ -22,6 +22,7 @@ FORMS    += espmonmain.ui
 
 INCLUDEPATH += $(PROFPGA)/include
 INCLUDEPATH += $(DESIGN_DIR)
+INCLUDEPATH += $(ESP_CFG_DIR)
 DEPENDPATH += $(PROFPGA)/include
 
 unix:!macx: QMAKE_CXXFLAGS += -Wno-narrowing

--- a/tools/socgen/soc.py
+++ b/tools/socgen/soc.py
@@ -378,14 +378,14 @@ class SoC_Config():
     self.LINUX_MAC = LINUX_MAC
     self.LEON3_STACK = LEON3_STACK
     #define whether SGMII has to be used or not: it is not used for PROFPGA boards
-    with open("Makefile") as fp:
+    with open("../../Makefile") as fp:
       for line in fp:
         if line.find("BOARD") != -1 and line.find("profpga") != -1:
           self.HAS_SGMII = False
     IPM = ""
     IPL = ""
     #determine other parameters
-    with open("grlib_config.vhd") as fp:
+    with open("../grlib/grlib_config.vhd") as fp:
       for line in fp:
         #check if the CPU is configured to used the CPU
         if line.find("CFG_FPU : integer") != -1:

--- a/tools/socgen/socmap_gen.py
+++ b/tools/socgen/socmap_gen.py
@@ -1685,7 +1685,7 @@ def print_tiles(fp, esp_config):
 def print_esplink_header(fp, esp_config, soc):
 
   # Get CPU base frequency
-  with open("top.vhd") as top_fp:
+  with open("../../top.vhd") as top_fp:
     for line in top_fp:
       if line.find("constant CPU_FREQ : integer") != -1:
         line.strip();
@@ -1714,7 +1714,7 @@ def print_esplink_header(fp, esp_config, soc):
 def print_devtree(fp, esp_config):
 
   # Get CPU base frequency
-  with open("top.vhd") as top_fp:
+  with open("../../top.vhd") as top_fp:
     for line in top_fp:
       if line.find("constant CPU_FREQ : integer") != -1:
         line.strip();

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -5,6 +5,30 @@
 ###    ESP Makefile    ###
 ##########################
 
+### Set variables needed before including the other makefiles
+SOFT              = $(ESP_ROOT)/soft/$(CPU_ARCH)
+BOOTROM_PATH      = $(SOFT)/bootrom
+LINUXSRC          = $(SOFT)/linux
+DRIVERS           = $(ESP_ROOT)/soft/common/drivers
+DRV_BARE          = $(DRIVERS)/baremetal
+DRV_LINUX         = $(DRIVERS)/linux
+CONTIG_ALLOC_PATH = $(DRV_LINUX)/contig_alloc
+ESP_CORE_PATH     = $(DRV_LINUX)/esp
+FLISTS            = $(ESP_ROOT)/utils/flist
+SOFT_BUILD        = $(DESIGN_PATH)/soft-build/$(CPU_ARCH)
+BUILD_DRIVERS     = $(SOFT_BUILD)/drivers
+BAREMETAL_BIN     = $(SOFT_BUILD)/baremetal
+
+CFG_BUILD       = socgen
+GRLIB_CFG_BUILD = $(CFG_BUILD)/grlib
+ESP_CFG_BUILD   = $(CFG_BUILD)/esp
+RTL_CFG_BUILD   = $(CFG_BUILD)/flist
+ESPMON_BUILD    = espmon
+
+LOGS = logs
+HLS_LOGS = $(LOGS)/hls
+VIVADO_LOGS = $(LOGS)/vivado
+
 ### Quick help ###
 include $(ESP_ROOT)/utils/make/help.mk
 
@@ -19,21 +43,6 @@ NOC_WIDTH = 64
 else
 NOC_WIDTH = 32
 endif
-
-
-### Set variables needed before including accelerators.mk
-SOFT              = $(ESP_ROOT)/soft/$(CPU_ARCH)
-BOOTROM_PATH      = $(SOFT)/bootrom
-LINUXSRC          = $(SOFT)/linux
-DRIVERS           = $(ESP_ROOT)/soft/common/drivers
-DRV_BARE          = $(DRIVERS)/baremetal
-DRV_LINUX         = $(DRIVERS)/linux
-CONTIG_ALLOC_PATH = $(DRV_LINUX)/contig_alloc
-ESP_CORE_PATH     = $(DRV_LINUX)/esp
-FLISTS            = $(ESP_ROOT)/utils/flist
-SOFT_BUILD        = $(DESIGN_PATH)/soft-build/$(CPU_ARCH)
-BUILD_DRIVERS     = $(SOFT_BUILD)/drivers
-BAREMETAL_BIN     = $(SOFT_BUILD)/baremetal
 
 
 ### Include targets to generate accelerators RTL with HLS ###
@@ -174,8 +183,7 @@ clean: 		soft-clean		\
 		mmi64-clean		\
 		soft-build-clean
 
-distclean:	check_all_srcs-distclean 	\
-		check_all_rtl_srcs-distclean	\
+distclean:	check_srcs-distclean     	\
 		xilinx_lib-clean 		\
 		profpga-distclean		\
 		soft-distclean 			\
@@ -186,8 +194,7 @@ distclean:	check_all_srcs-distclean 	\
 		qsim-distclean			\
 		ncsim-distclean			\
 		xmsim-distclean			\
-		esp-config-distclean		\
-		grlib-config-distclean		\
+		config-distclean		\
 		vivado-distclean		\
 		zynq-distclean			\
 		genus-distclean			\
@@ -195,7 +202,7 @@ distclean:	check_all_srcs-distclean 	\
 		espmon-distclean		\
 		mmi64-distclean			\
 		soft-build-distclean
-	$(QUIET_CLEAN)$(RM) *.log
+	$(QUIET_CLEAN)$(RM) $(LOGS)
 
 
 .PHONY: clean distclean

--- a/utils/make/ariane.mk
+++ b/utils/make/ariane.mk
@@ -24,7 +24,7 @@ soft-clean:
 
 soft-distclean: soft-clean
 
-$(SOFT_BUILD)/riscv.dtb: riscv.dts socmap.vhd
+$(SOFT_BUILD)/riscv.dtb: $(ESP_CFG_BUILD)/riscv.dts $(ESP_CFG_BUILD)/socmap.vhd
 	$(QUIET_BUILD) mkdir -p $(SOFT_BUILD)
 	@dtc -I dts $< -O dtb -o $@
 
@@ -37,24 +37,24 @@ $(SOFT_BUILD)/startup.o: $(BOOTROM_PATH)/startup.S $(SOFT_BUILD)/riscv.dtb
 		-I$(BOOTROM_PATH) \
 		-c $< -o startup.o
 
-$(SOFT_BUILD)/main.o: $(BOOTROM_PATH)/main.c socmap.h
+$(SOFT_BUILD)/main.o: $(BOOTROM_PATH)/main.c $(ESP_CFG_BUILD)/socmap.h
 	@mkdir -p $(SOFT_BUILD)
 	$(QUIET_CC) $(CROSS_COMPILE_ELF)gcc \
 		-Os \
 		-Wall -Werror \
 		-mcmodel=medany -mexplicit-relocs \
 		-I$(BOOTROM_PATH) \
-		-I$(DESIGN_PATH) \
+		-I$(DESIGN_PATH)/$(ESP_CFG_BUILD) \
 		-c $< -o $@
 
-$(SOFT_BUILD)/uart.o: $(BOOTROM_PATH)/uart.c socmap.h
+$(SOFT_BUILD)/uart.o: $(BOOTROM_PATH)/uart.c $(ESP_CFG_BUILD)/socmap.h
 	@mkdir -p $(SOFT_BUILD)
 	$(QUIET_CC) $(CROSS_COMPILE_ELF)gcc \
 		-Os \
 		-Wall -Werror \
 		-mcmodel=medany -mexplicit-relocs \
 		-I$(BOOTROM_PATH) \
-		-I$(DESIGN_PATH) \
+		-I$(DESIGN_PATH)/$(ESP_CFG_BUILD) \
 		-c $< -o $@
 
 $(SOFT_BUILD)/prom.exe: $(SOFT_BUILD)/startup.o $(SOFT_BUILD)/uart.o $(SOFT_BUILD)/main.o $(BOOTROM_PATH)/linker.lds
@@ -64,7 +64,7 @@ $(SOFT_BUILD)/prom.exe: $(SOFT_BUILD)/startup.o $(SOFT_BUILD)/uart.o $(SOFT_BUIL
 		-Wall -Werror \
 		-mcmodel=medany -mexplicit-relocs \
 		-I$(BOOTROM_PATH) \
-		-I$(DESIGN_PATH) \
+		-I$(DESIGN_PATH)/$(ESP_CFG_BUILD) \
 		-nostdlib -nodefaultlibs -nostartfiles \
 		-T$(BOOTROM_PATH)/linker.lds \
 		$(SOFT_BUILD)/startup.o $(SOFT_BUILD)/uart.o $(SOFT_BUILD)/main.o \
@@ -98,7 +98,7 @@ $(SOFT_BUILD)/systest.exe: systest.c $(SOFT_BUILD)/uart.o
 	$(SOFT)/common/syscalls.c \
 	$(RISCV_TESTS)/benchmarks/common/crt.S  \
 	-T $(RISCV_TESTS)/benchmarks/common/test.ld -o $@ \
-	-I$(DESIGN_PATH) \
+	-I$(DESIGN_PATH)/$(ESP_CFG_BUILD) \
 	$(SOFT_BUILD)/uart.o $<
 
 $(SOFT_BUILD)/systest.bin: $(TEST_PROGRAM)
@@ -208,7 +208,7 @@ XMLOGOPT += -DEFINE WT_DCACHE=1
 ifeq ("$(CPU_ARCH)", "ariane")
 INCDIR += $(ARIANE)/src/common_cells/include
 VERILOG_ARIANE += $(foreach f, $(shell strings $(FLISTS)/ariane_vlog.flist), $(ARIANE)/$(f))
-VERILOG_ARIANE += $(DESIGN_PATH)/plic_regmap.sv
+VERILOG_ARIANE += $(DESIGN_PATH)/$(ESP_CFG_BUILD)/plic_regmap.sv
 ifneq ($(filter $(TECHLIB),$(FPGALIBS)),)
 VERILOG_ARIANE += $(foreach f, $(shell strings $(FLISTS)/ariane_fpga_vlog.flist), $(ARIANE)/$(f))
 endif

--- a/utils/make/design.mk
+++ b/utils/make/design.mk
@@ -50,8 +50,8 @@ endif
 
 
 ### Include grlib and ESP configuration (remake may occur) ###
--include .grlib_config
--include .esp_config
+-include $(GRLIB_CFG_BUILD)/.grlib_config
+-include $(ESP_CFG_BUILD)/.esp_config
 
 
 ### Toolchain
@@ -83,14 +83,14 @@ LINUX_MAC ?= $(shell echo 0000$$(dd if=/dev/urandom count=1 2>/dev/null | md5sum
 
 
 ### Common design files ###
-SOCKETGEN_VHDL_RTL_PKGS += $(DESIGN_PATH)/esp_global.vhd
+SOCKETGEN_VHDL_RTL_PKGS += $(DESIGN_PATH)/$(ESP_CFG_BUILD)/esp_global.vhd
 SOCKETGEN_VHDL_RTL_PKGS += $(DESIGN_PATH)/socketgen/sld_devices.vhd
 SOCKETGEN_VHDL_RTL_PKGS += $(DESIGN_PATH)/socketgen/allacc.vhd
 SOCKETGEN_VHDL_RTL_PKGS += $(DESIGN_PATH)/socketgen/genacc.vhd
 SOCKETGEN_VHDL_RTL_PKGS += $(DESIGN_PATH)/socketgen/allcaches.vhd
 
-TOP_VHDL_RTL_PKGS += $(DESIGN_PATH)/grlib_config.vhd
-TOP_VHDL_RTL_PKGS += $(DESIGN_PATH)/socmap.vhd
+TOP_VHDL_RTL_PKGS += $(DESIGN_PATH)/$(GRLIB_CFG_BUILD)/grlib_config.vhd
+TOP_VHDL_RTL_PKGS += $(DESIGN_PATH)/$(ESP_CFG_BUILD)/socmap.vhd
 TOP_VHDL_RTL_PKGS += $(DESIGN_PATH)/socketgen/sldacc.vhd
 TOP_VHDL_RTL_PKGS += $(ESP_ROOT)/rtl/tiles/tiles_pkg.vhd
 TOP_VHDL_RTL_PKGS += $(EXTRA_TOP_VHDL_RTL_PKGS)

--- a/utils/make/esp.mk
+++ b/utils/make/esp.mk
@@ -3,75 +3,79 @@
 
 ESP_DEFCONFIG ?= $(ESP_ROOT)/socs/defconfig/esp_$(BOARD)_defconfig
 
-.esp_config:
+$(ESP_CFG_BUILD):
+	$(QUIET_MKDIR)mkdir -p $(ESP_CFG_BUILD)
+
+$(ESP_CFG_BUILD)/.esp_config:
+	$(QUIET_MKDIR)mkdir -p $(ESP_CFG_BUILD)
 	$(QUIET_CP)cp $(ESP_DEFCONFIG) $@
 
-esp-defconfig: $(ESP_DEFCONFIG)
-	$(QUIET_CP)cp $< .esp_config
-	$(QUIET_MAKE)$(MAKE) esp-config
+esp-defconfig: $(ESP_CFG_BUILD) $(ESP_DEFCONFIG)
+	$(QUIET_CP) \
+	cd $(ESP_CFG_BUILD); \
+	cp $< .esp_config
+	$(QUIET_MAKE) \
+	cd $(ESP_CFG_BUILD); \
+	$(MAKE) esp-config
 
-socmap.vhd: .esp_config grlib_config.vhd top.vhd Makefile
+$(ESP_CFG_BUILD)/socmap.vhd: $(ESP_CFG_BUILD)/.esp_config $(GRLIB_CFG_BUILD)/grlib_config.vhd top.vhd Makefile
 	$(QUIET_DIFF)echo "checking .esp_config..."
-	@/usr/bin/diff .esp_config $(ESP_DEFCONFIG) -q > /dev/null; \
+	@cd $(ESP_CFG_BUILD); \
+	/usr/bin/diff .esp_config $(ESP_DEFCONFIG) -q > /dev/null; \
 	if test $$? = "0"; then \
 		echo $(SPACES)"INFO Using default configuration file for ESP"; \
 	else \
 		echo $(SPACES)"INFO Using custom configuration found in \".esp_config\" for ESP"; \
-	fi
-	@echo ""
-	@echo "Generating ESP configuration..."
-	@LD_LIBRARY_PATH="" xvfb-run -a python3 $(ESP_ROOT)/tools/socgen/esp_creator_batch.py $(NOC_WIDTH) $(TECHLIB) $(LINUX_MAC) $(LEON3_STACK)
+	fi; \
+	echo ""; \
+	echo "Generating ESP configuration..."; \
+	LD_LIBRARY_PATH="" xvfb-run -a python3 $(ESP_ROOT)/tools/socgen/esp_creator_batch.py $(NOC_WIDTH) $(TECHLIB) $(LINUX_MAC) $(LEON3_STACK)
 
-socmap.h: socmap.vhd
+$(ESP_CFG_BUILD)/socmap.h: $(ESP_CFG_BUILD)/socmap.vhd
 
 ESPLINK_SRCS = $(wildcard $(ESP_ROOT)/tools/esplink/src/*.c)
 ESPLINK_HDRS = $(wildcard $(ESP_ROOT)/tools/esplink/src/*.h)
-esplink: socmap.h $(ESPLINK_HDRS) $(ESPLINK_SRCS)
-	$(QUIET_CC) gcc -O3 -Wall -Werror -fmax-errors=5 \
+esplink: $(ESP_CFG_BUILD)/socmap.h $(ESPLINK_HDRS) $(ESPLINK_SRCS)
+	$(QUIET_CC) \
+	cd $(ESP_CFG_BUILD); \
+	gcc -O3 -Wall -Werror -fmax-errors=5 \
 		-DESPLINK_IP=\"$(ESPLINK_IP)\" -DPORT=$(ESPLINK_PORT) \
-		-I$(ESP_ROOT)/tools/esplink/src/ -I$(DESIGN_PATH) \
+		-I$(ESP_ROOT)/tools/esplink/src/ -I$(DESIGN_PATH)/$(ESP_CFG_BUILD) \
 		$(ESPLINK_SRCS) -o $@
 
-esp-config: socmap.vhd
+esp-config: $(ESP_CFG_BUILD)/socmap.vhd
 
-esp-xconfig: grlib_config.vhd
+esp-xconfig: $(ESP_CFG_BUILD) $(GRLIB_CFG_BUILD)/grlib_config.vhd
 	@echo ""
 	@echo "Running interactive ESP configuration..."
-	@LD_LIBRARY_PATH="" python3 $(ESP_ROOT)/tools/socgen/esp_creator.py $(NOC_WIDTH) $(TECHLIB) $(LINUX_MAC) $(LEON3_STACK)
+	@cd $(ESP_CFG_BUILD); \
+	LD_LIBRARY_PATH="" python3 $(ESP_ROOT)/tools/socgen/esp_creator.py $(NOC_WIDTH) $(TECHLIB) $(LINUX_MAC) $(LEON3_STACK)
 
 esp-config-clean:
 	$(QUIET_CLEAN)$(RM) \
-		.esp_config.bak
+		$(ESP_CFG_BUILD)/.esp_config.bak
 
 ifneq ("$(CPU_ARCH)", "leon3")
-riscv.dts: .esp_config grlib_config.vhd top.vhd
-	$(QUIET_MAKE) $(MAKE) socmap.vhd
+$(ESP_CFG_BUILD)/riscv.dts: $(ESP_CFG_BUILD)/.esp_config $(GRLIB_CFG_BUILD)/grlib_config.vhd top.vhd
+	$(QUIET_MAKE) \
+	cd $(ESP_CFG_BUILD); \
+	$(MAKE) socmap.vhd
 
 ARIANE_RV_PLIC_REGMAP_GEN = $(ESP_ROOT)/rtl/cores/ariane/ariane/src/rv_plic/rtl/gen_plic_addrmap.py
 
-plic_regmap.sv: $(ARIANE_RV_PLIC_REGMAP_GEN) .esp_config
+$(ESP_CFG_BUILD)/plic_regmap.sv: $(ARIANE_RV_PLIC_REGMAP_GEN) $(ESP_CFG_BUILD)/.esp_config
 	$(QUIET_MAKE)$< -t $$(($(NCPU_TILE)*2)) > $@
 endif
 
 ifeq ("$(CPU_ARCH)", "leon3")
-plic_regmap.sv:
+$(ESP_CFG_BUILD)/plic_regmap.sv:
 
 endif
 
-esp-config-distclean: esp-config-clean
-	$(QUIET_CLEAN)$(RM)	\
-		socmap.vhd	\
-		esp_global.vhd	\
-		.esp_config	\
-		.soft_config	\
-		riscv.dts	\
-		plic_regmap.sv	\
-		mmi64_regs.h	\
-		power.h		\
-		socmap.h	\
-		cache_cfg.svh	\
-		S64esp		\
-		esplink
+esp-config-distclean:
+	$(QUIET_CLEAN)$(RM) $(ESP_CFG_BUILD)
 
+config-distclean:
+	$(QUIET_CLEAN)$(RM) $(CFG_BUILD)
 
-.PHONY: esplink esp-xconfig esp-defconfig esp-config-clean esp-config-distclean
+.PHONY: esplink esp-xconfig esp-defconfig esp-config-clean esp-config-distclean config-distclean

--- a/utils/make/examples.mk
+++ b/utils/make/examples.mk
@@ -1,63 +1,27 @@
-
 EXAMPLES_PATH = $(ESP_ROOT)/soft/common/apps/examples/
-EXAMPLES_OUT_PATH = $(DESIGN_PATH)/examples
+EXAMPLES_OUT_PATH = $(SOFT_BUILD)/apps/examples
 
 EXAMPLES = $(filter-out common, $(shell ls -d $(EXAMPLES_PATH)/*/ | awk -F/ '{print $$(NF-1)}'))
-EXAMPLES_TARGET = $(foreach e, $(EXAMPLES), $(EXAMPLES_OUT_PATH)/$(e)/$(e).exe)
 
-EXAMPLE_CFLAGS =
+EXAMPLES_OUT_PATHS = $(addprefix  $(EXAMPLES_OUT_PATH)/, $(EXAMPLES))
 
-ifeq ("$(CPU_ARCH)", "leon3")
-# uclibc does not have sinf()
-EXAMPLE_CFLAGS += -fno-builtin-cos -fno-builtin-sin
-endif
-
-EXAMPLE_CFLAGS += -O3
-EXAMPLE_CFLAGS += -Wall
-EXAMPLE_CFLAGS += -I$(DRV_LINUX)/include -I$(DRIVERS)/common/include
-EXAMPLE_CFLAGS += -I$(EXAMPLES_PATH)/$(EXAMPLE)
-
-EXAMPLE_LDLIBS += -L$(BUILD_DRIVERS)/contig_alloc
-EXAMPLE_LDLIBS += -L$(BUILD_DRIVERS)/test
-EXAMPLE_LDLIBS += -L$(BUILD_DRIVERS)/libesp
-EXAMPLE_LDLIBS += -L$(BUILD_DRIVERS)/utils/linux
-
-EXAMPLE_LDFLAGS += -lm -lrt -lpthread -lesp -ltest -lcontig -lutils
-
-EXAMPLE_CC = gcc
-EXAMPLE_LD = $(CROSS_COMPILE_LINUX)$(LD)
-
-EXAMPLE_SRCS = $(foreach f, $(wildcard $(EXAMPLES_PATH)/$(EXAMPLE)/*.c), $(shell basename $(f)))
-EXAMPLE_HDRS = $(wildcard $(EXAMPLES_PATH)/$(EXAMPLE)/*.h)
-EXAMPLE_OBJS = $(EXAMPLE_SRCS:.c=.o)
-
-$(EXAMPLES_OUT_PATH)/$(EXAMPLE):
+$(EXAMPLES_OUT_PATHS):
 	@$(QUIET_MKDIR) mkdir -p $@
-
-$(EXAMPLES_OUT_PATH)/$(EXAMPLE)/%.o: $(EXAMPLES_PATH)/$(EXAMPLE)/%.c
-	@$(MAKE) $(EXAMPLES_OUT_PATH)/$(EXAMPLE)
-	$(QUIET_CC) $(CROSS_COMPILE_LINUX)$(EXAMPLE_CC) $(EXAMPLE_CFLAGS) -c -o $@ $<
-
-$(EXAMPLES_OUT_PATH)/$(EXAMPLE)/$(EXAMPLE_OBJS): $(EXAMPLE_HDRS)
-
-
-$(EXAMPLES_OUT_PATH)/$(EXAMPLE)/$(EXAMPLE).exe: $(EXAMPLES_OUT_PATH)/$(EXAMPLE)/$(EXAMPLE_OBJS)
-	$(QUIET_LINK) $(CROSS_COMPILE_LINUX)$(EXAMPLE_CC) $(EXAMPLE_LDLIBS) -o $@ $^ $(EXAMPLE_LDFLAGS)
-
 
 define EXAMPLES_GEN
 
-$(1):
-	@$(MAKE) EXAMPLE=$(1) $(EXAMPLES_OUT_PATH)/$(1)/$(1).exe
+$(1):  $(EXAMPLES_OUT_PATH)/$(1)
+	@CPU_ARCH=$(CPU_ARCH) DRIVERS=$(DRV_LINUX) BUILD_PATH=$(EXAMPLES_OUT_PATH)/$(1) BUILD_DRIVERS=$(SOFT_BUILD)/drivers $(MAKE) -C $(EXAMPLES_PATH)/$(1)
 
 endef
 
 $(foreach e, $(EXAMPLES), $(eval $(call EXAMPLES_GEN,$(e))))
 
-examples: $(EXAMPLES)
+examples: soft-build $(EXAMPLES) $(SOFT_BUILD)/sysroot
+	$(QUIET_CP)cp -r $(EXAMPLES_OUT_PATH) $(SOFT_BUILD)/sysroot
 
 examples-clean:
-	$(QUIET_CLEAN) $(RM) $(DESIGN_PATH)/examples
+	$(QUIET_CLEAN) $(RM) $(EXAMPLES_OUT_PATH)
 
 
-.PHONY: examples examples-clean $(EXAMPLES)
+.PHONY: examples examples-clean $(EXAMPLES) examples-copy

--- a/utils/make/fpga.mk
+++ b/utils/make/fpga.mk
@@ -13,16 +13,16 @@ endif
 
 
 fpga-run: esplink soft
-	@./esplink --reset
-	@./esplink --brom -i $(SOFT_BUILD)/prom.bin
-	@./esplink --dram -i $(SOFT_BUILD)/systest.bin
-	@./esplink --reset
+	@./$(ESP_CFG_BUILD)/esplink --reset
+	@./$(ESP_CFG_BUILD)/esplink --brom -i $(SOFT_BUILD)/prom.bin
+	@./$(ESP_CFG_BUILD)/esplink --dram -i $(SOFT_BUILD)/systest.bin
+	@./$(ESP_CFG_BUILD)/esplink --reset
 
-fpga-run-linux: esplink fpga-program soft
-	@./esplink --reset
-	@./esplink --brom -i $(SOFT_BUILD)/prom.bin
-	@./esplink --dram -i $(SOFT_BUILD)/linux.bin
-	@./esplink --reset
+fpga-run-linux: esplink soft
+	@./$(ESP_CFG_BUILD)/esplink --reset
+	@./$(ESP_CFG_BUILD)/esplink --brom -i $(SOFT_BUILD)/prom.bin
+	@./$(ESP_CFG_BUILD)/esplink --dram -i $(SOFT_BUILD)/linux.bin
+	@./$(ESP_CFG_BUILD)/esplink --reset
 
 
 .PHONY: fpga-run fpga-run-linux fpga-program

--- a/utils/make/genus.mk
+++ b/utils/make/genus.mk
@@ -21,11 +21,11 @@ genus:
 	$(QUIET_MKDIR)mkdir -p genus
 
 
-genus/incdir.tcl: genus check_all_rtl_srcs.old
+genus/incdir.tcl: genus $(RTL_CFG_BUILD)/check_all_rtl_srcs.old
 	$(QUIET_MAKE) \
 	echo "set log_syn(hdl_search_path) \"$(INCDIR)\"" > $@
 
-genus/srcs.tcl: genus check_all_rtl_srcs.old
+genus/srcs.tcl: genus $(RTL_CFG_BUILD)/check_all_rtl_srcs.old
 	$(QUIET_MAKE) $(RM) $@
 	@echo "### Compile VHDL packages ###" >> $@; \
 	for vhd in $(VHDL_PKGS); do \

--- a/utils/make/ibex.mk
+++ b/utils/make/ibex.mk
@@ -24,7 +24,7 @@ soft-clean:
 
 soft-distclean: soft-clean
 
-$(SOFT_BUILD)/riscv.dtb: riscv.dts socmap.vhd
+$(SOFT_BUILD)/riscv.dtb: $(ESP_CFG_BUILD)/riscv.dts $(ESP_CFG_BUILD)/socmap.vhd
 	$(QUIET_BUILD) mkdir -p $(SOFT_BUILD)
 	$(QUIET_BUILD) dtc -I dts $< -O dtb -o $@
 
@@ -36,11 +36,11 @@ $(SOFT_BUILD)/startup.o: $(BOOTROM_PATH)/startup.S $(SOFT_BUILD)/riscv.dtb
 		-mcmodel=medany -mexplicit-relocs \
 		-march=rv32imc -mabi=ilp32 \
 		-mstrict-align \
-		-I$(DESIGN_PATH) \
+		-I$(DESIGN_PATH)/$(ESP_CFG_BUILD) \
 		-I$(BOOTROM_PATH) \
 		-c $< -o $@
 
-$(SOFT_BUILD)/main.o: $(BOOTROM_PATH)/main.c socmap.h
+$(SOFT_BUILD)/main.o: $(BOOTROM_PATH)/main.c $(ESP_CFG_BUILD)/socmap.h
 	$(QUIET_BUILD) mkdir -p $(SOFT_BUILD)
 	$(QUIET_CC) $(CROSS_COMPILE_ELF)gcc \
 		-Os \
@@ -49,10 +49,10 @@ $(SOFT_BUILD)/main.o: $(BOOTROM_PATH)/main.c socmap.h
 		-march=rv32imc -mabi=ilp32 \
 		-mstrict-align \
 		-I$(BOOTROM_PATH) \
-		-I$(DESIGN_PATH) \
+		-I$(DESIGN_PATH)/$(ESP_CFG_BUILD) \
 		-c $< -o $@
 
-$(SOFT_BUILD)/uart.o: $(BOOTROM_PATH)/uart.c socmap.h
+$(SOFT_BUILD)/uart.o: $(BOOTROM_PATH)/uart.c $(ESP_CFG_BUILD)/socmap.h
 	$(QUIET_BUILD) mkdir -p $(SOFT_BUILD)
 	$(QUIET_CC) $(CROSS_COMPILE_ELF)gcc \
 		-Os \
@@ -61,7 +61,7 @@ $(SOFT_BUILD)/uart.o: $(BOOTROM_PATH)/uart.c socmap.h
 		-march=rv32imc -mabi=ilp32 \
 		-mstrict-align \
 		-I$(BOOTROM_PATH) \
-		-I$(DESIGN_PATH) \
+		-I$(DESIGN_PATH)/$(ESP_CFG_BUILD) \
 		-c $< -o $@
 
 $(SOFT_BUILD)/prom.exe: $(SOFT_BUILD)/startup.o $(SOFT_BUILD)/uart.o $(SOFT_BUILD)/main.o $(BOOTROM_PATH)/linker.lds
@@ -72,7 +72,7 @@ $(SOFT_BUILD)/prom.exe: $(SOFT_BUILD)/startup.o $(SOFT_BUILD)/uart.o $(SOFT_BUIL
 		-march=rv32imc -mabi=ilp32 \
 		-mstrict-align \
 		-I$(BOOTROM_PATH) \
-		-I$(DESIGN_PATH) \
+		-I$(DESIGN_PATH)/$(ESP_CFG_BUILD) \
 		-nodefaultlibs -nostartfiles \
 		-T$(BOOTROM_PATH)/linker.lds \
 		$(SOFT_BUILD)/startup.o $(SOFT_BUILD)/uart.o $(SOFT_BUILD)/main.o -lgcc\
@@ -104,7 +104,7 @@ $(SOFT_BUILD)/systest.exe: systest.c $(SOFT_BUILD)/uart.o
 	$(SOFT)/common/syscalls.c \
 	$(RISCV_TESTS)/benchmarks/common/crt.S  \
 	-T $(RISCV_TESTS)/benchmarks/common/test.ld -o $@ \
-	-I$(DESIGN_PATH) \
+	-I$(DESIGN_PATH)/$(ESP_CFG_BUILD) \
 	$(SOFT_BUILD)/uart.o -lm -lgcc $<
 
 $(SOFT_BUILD)/systest.bin: $(TEST_PROGRAM)
@@ -161,6 +161,6 @@ XMLOGOPT += -UNCLOCKEDSVA
 ifeq ("$(CPU_ARCH)", "ibex")
 INCDIR  += $(IBEX)/vendor/lowrisc_ip/ip/prim/rtl
 VERILOG_IBEX += $(foreach f, $(shell strings $(FLISTS)/ibex_vlog.flist), $(IBEX)/$(f))
-VERILOG_IBEX += $(DESIGN_PATH)/plic_regmap.sv
+VERILOG_IBEX += $(DESIGN_PATH)/$(ESP_CFG_BUILD)/plic_regmap.sv
 THIRDPARTY_VLOG += $(VERILOG_IBEX)
 endif

--- a/utils/make/modelsim.mk
+++ b/utils/make/modelsim.mk
@@ -59,7 +59,7 @@ modelsim/modelsim.ini: $(ESP_ROOT)/.cache/modelsim/xilinx_lib
 # Note that vmake fails to find unisim.vcomponents, however produces the correct
 # makefile for future compilation and all components are properly bound in simulation.
 # Please keep 2> /dev/null until the bug is fixed with a newer Modelsim release.
-modelsim/vsim.mk: modelsim/modelsim.ini check_all_srcs.old $(PKG_LIST)
+modelsim/vsim.mk: modelsim/modelsim.ini $(RTL_CFG_BUILD)/check_all_srcs.old $(PKG_LIST)
 	@cd modelsim; \
 	if ! test -e profpga; then \
 		vlib -type directory profpga; \

--- a/utils/make/ncsim.mk
+++ b/utils/make/ncsim.mk
@@ -48,7 +48,7 @@ incisive/cds.lib: $(ESP_ROOT)/.cache/incisive/xilinx_lib
 incisive/hdl.var: incisive/cds.lib
 	@cp $(ESP_ROOT)/.cache/incisive/hdl.var $@
 
-incisive/ncready: incisive/hdl.var check_all_srcs.old $(PKG_LIST)
+incisive/ncready: incisive/hdl.var $(RTL_CFG_BUILD)/check_all_srcs.old $(PKG_LIST)
 	$(QUIET_MKDIR)mkdir -p incisive
 	@echo $(SPACES)"WARNING: The source code for Ariane cannot be compiled with Incisive!!! If you need Ariane, please switch to Modelsim or Xcelium";
 	@cd incisive; \

--- a/utils/make/questa.mk
+++ b/utils/make/questa.mk
@@ -39,7 +39,7 @@ questa/modelsim.ini: $(ESP_ROOT)/.cache/questa/xilinx_lib
 # Note that vmake fails to find unisim.vcomponents, however produces the correct
 # makefile for future compilation and all components are properly bound in simulation.
 # Please keep 2> /dev/null until the bug is fixed with a newer Modelsim release.
-questa/vsim.mk: questa/modelsim.ini check_all_srcs.old $(PKG_LIST)
+questa/vsim.mk: questa/modelsim.ini $(RTL_CFG_BUILD)/check_all_srcs.old $(PKG_LIST)
 	@cd questa; \
 	if ! test -e profpga; then \
 		vlib -type directory profpga; \

--- a/utils/make/rtl.mk
+++ b/utils/make/rtl.mk
@@ -4,6 +4,8 @@
 
 ### Include paths ###
 INCDIR += $(DESIGN_PATH)
+INCDIR += $(DESIGN_PATH)/$(GRLIB_CFG_BUILD)
+INCDIR += $(DESIGN_PATH)/$(ESP_CFG_BUILD)
 INCDIR += $(THIRDPARTY_INCDIR)
 INCDIR += $(ESP_ROOT)/rtl/caches/esp-caches/common/defs
 
@@ -56,42 +58,48 @@ DAT_SRCS = $(shell (find $(ESP_ROOT)/tech/$(TECHLIB)/ -name "*.dat" ))
 ALL_SIM_SRCS  = $(SIM_VHDL_PKGS) $(SIM_VHDL_SRCS) $(SIM_VLOG_SRCS) $(IP_XCI_SRCS) $(DAT_SRCS)
 ALL_RTL_SRCS  = $(VHDL_PKGS) $(VHDL_SRCS) $(VLOG_SRCS) $(IP_XCI_SRCS) $(DAT_SRCS)
 
-check_all_srcs: grlib_config.vhd socmap.vhd socketgen plic_regmap.sv
+$(RTL_CFG_BUILD):
+	$(QUIET_MKDIR)mkdir -p $(RTL_CFG_BUILD)
+
+check_all_srcs: $(GRLIB_CFG_BUILD)/grlib_config.vhd $(ESP_CFG_BUILD)/socmap.vhd socketgen $(ESP_CFG_BUILD)/plic_regmap.sv $(RTL_CFG_BUILD)
 	@echo $(ALL_SIM_SRCS) > $@.new; \
-	if test -f $@.old; then \
-		/usr/bin/diff -q $@.old $@.new > /dev/null; \
+	if test -f $(RTL_CFG_BUILD)/$@.old; then \
+		/usr/bin/diff -q $(RTL_CFG_BUILD)/$@.old $@.new > /dev/null; \
 		if [ $$? -eq 0 ]; then \
 			rm $@.new; \
 		else \
 			rm -rf modelsim/work; \
 			rm -rf modelsim/vsim.mk; \
-			mv $@.new $@.old; \
+			mv $@.new $(RTL_CFG_BUILD)/$@.old; \
 		fi; \
 	else \
 		rm -rf modelsim/work; \
 		rm -rf modelsim/vsim.mk; \
-		mv $@.new $@.old; \
+		mv $@.new $(RTL_CFG_BUILD)/$@.old; \
 	fi;
 
 check_all_srcs-distclean:
-	$(QUIET_CLEAN)rm -rf check_all_srcs.old
+	$(QUIET_CLEAN)rm -rf $(RTL_CFG_BUILD)/check_all_srcs.old
 
 .PHONY: check_all_srcs check_all_srcs-distclean
 
-check_all_rtl_srcs: grlib_config.vhd socmap.vhd socketgen plic_regmap.sv
+check_all_rtl_srcs: $(GRLIB_CFG_BUILD)/grlib_config.vhd $(ESP_CFG_BUILD)/socmap.vhd socketgen $(ESP_CFG_BUILD)/plic_regmap.sv $(RTL_CFG_BUILD)
 	@echo $(ALL_RTL_SRCS) > $@.new; \
 	if test -f $@.old; then \
-		/usr/bin/diff -q $@.old $@.new > /dev/null; \
+		/usr/bin/diff -q $(RTL_CFG_BUILD)/$@.old $@.new > /dev/null; \
 		if [ $$? -eq 0 ]; then \
 			rm $@.new; \
 		else \
-			mv $@.new $@.old; \
+			mv $@.new $(RTL_CFG_BUILD)/$@.old; \
 		fi; \
 	else \
-		mv $@.new $@.old; \
+		mv $@.new $(RTL_CFG_BUILD)/$@.old; \
 	fi;
 
 check_all_rtl_srcs-distclean:
-	$(QUIET_CLEAN)rm -rf check_all_rtl_srcs.old
+	$(QUIET_CLEAN)rm -rf $(RTL_CFG_BUILD)/check_all_rtl_srcs.old
 
-.PHONY: check_all_rtl_srcs check_all_rtl_srcs-distclean
+check_srcs-distclean:
+	$(QUIET_CLEAN)rm -rf $(RTL_CFG_BUILD)
+
+.PHONY: check_all_rtl_srcs check_all_rtl_srcs-distclean check_srcs-distclean

--- a/utils/make/soft_common.mk
+++ b/utils/make/soft_common.mk
@@ -46,7 +46,7 @@ $(SOFT_BUILD)/sysroot/opt/drivers-esp/esp.ko: $(SOFT_BUILD)/linux-build/vmlinux 
 # This is a PHONY to guarantee sysroot is always updated when apps or drivers change
 # Most targets won't actually do anything if their dependencies have not changed.
 # Linux is compiled twice if necessary to ensure drivers are compiled against the most recent kernel
-sysroot-update: $(SOFT_BUILD)/linux-build/vmlinux socmap.vhd soft-build
+sysroot-update: $(SOFT_BUILD)/linux-build/vmlinux $(ESP_CFG_BUILD)/socmap.vhd soft-build
 	@touch $(SOFT_BUILD)/sysroot
 	@$(MAKE) $(SOFT_BUILD)/sysroot/opt/drivers-esp/contig_alloc.ko
 	@$(MAKE) $(SOFT_BUILD)/sysroot/opt/drivers-esp/esp_cache.ko
@@ -58,7 +58,7 @@ sysroot-update: $(SOFT_BUILD)/linux-build/vmlinux socmap.vhd soft-build
 	@$(MAKE) acc-driver
 	@$(MAKE) acc-app
 	@touch $(SOFT_BUILD)/sysroot
-	@chmod a+x S64esp; cp S64esp $(SOFT_BUILD)/sysroot/etc/init.d/
+	@chmod a+x $(ESP_CFG_BUILD)/S64esp; cp $(ESP_CFG_BUILD)/S64esp $(SOFT_BUILD)/sysroot/etc/init.d/
 	$(QUIET_MAKE)$(MAKE) $(SOFT_BUILD)/linux-build/vmlinux
 
 sysroot-clean:
@@ -84,10 +84,10 @@ $(SOFT_BUILD)/linux-build:
 $(BAREMETAL_BIN):
 	$(QUIET_MKDIR)mkdir -p $@
 
-baremetal-all: soft-build socmap.vhd
+baremetal-all: soft-build $(ESP_CFG_BUILD)/socmap.vhd
 	@mkdir -p $(BAREMETAL_BIN)/dvi
 	@mkdir -p $(BUILD_DRIVERS)/dvi/baremetal
-	@CPU_ARCH=$(CPU_ARCH) DESIGN_PATH=$(DESIGN_PATH) DRIVERS=$(DRV_BARE) BUILD_PATH=$(BUILD_DRIVERS)/dvi/baremetal $(MAKE) -C $(DRV_BARE)/dvi
+	@CPU_ARCH=$(CPU_ARCH) DESIGN_PATH=$(DESIGN_PATH)/$(ESP_CFG_BUILD) DRIVERS=$(DRV_BARE) BUILD_PATH=$(BUILD_DRIVERS)/dvi/baremetal $(MAKE) -C $(DRV_BARE)/dvi
 	@cp $(BUILD_DRIVERS)/dvi/baremetal/*.bin $(BAREMETAL_BIN)/dvi
 	@$(MAKE) acc-baremetal
 

--- a/utils/make/xmsim.mk
+++ b/utils/make/xmsim.mk
@@ -51,7 +51,7 @@ xcelium/hdl.var: xcelium/cds.lib
 
 
 ### Compile simulation source files ###
-xcelium/xmready: xcelium/hdl.var check_all_srcs.old $(PKG_LIST)
+xcelium/xmready: xcelium/hdl.var $(RTL_CFG_BUILD)/check_all_srcs.old $(PKG_LIST)
 	$(QUIET_MKDIR)mkdir -p xcelium
 	@cd xcelium; \
 	if ! grep --quiet "DEFINE profpga" cds.lib; then \


### PR DESCRIPTION
* Organize the spare files generated in the working folders.
* Avoid a device driver conflict for homonym accelerators from different design flows by renaming the device driver source files and some global structures and constants.