### PR TITLE
issue #96: use https for prebuilt images in toolchain scripts

### DIFF
--- a/utils/toolchain/build_leon3_toolchain.sh
+++ b/utils/toolchain/build_leon3_toolchain.sh
@@ -15,7 +15,7 @@ DEFAULT_TARGET_DIR="/opt/leon"
 TMP=/tmp/_leon3_build
 
 # Prebuilt from Cobham Gaisler
-SRC_MIRROR="http://espdev.cs.columbia.edu/stuff/leon3"
+SRC_MIRROR="https://espdev.cs.columbia.edu/stuff/leon3"
 BAREC_GCC_VERSION="4.4.2"
 MKLINUXIMG_VERSION="2.0.10"
 

--- a/utils/toolchain/build_riscv32imc_toolchain.sh
+++ b/utils/toolchain/build_riscv32imc_toolchain.sh
@@ -10,7 +10,6 @@ ESP_ROOT=$(realpath ${SCRIPT_PATH}/../..)
 RISCV_GNU_TOOLCHAIN_SHA=afcc8bc655d30cf6af054ac1d3f5f89d0627aa79
 
 DEFAULT_TARGET_DIR="/opt/riscv32imc"
-SRC_MIRROR="http://espdev.cs.columbia.edu/stuff/riscv"
 TMP=/tmp/_riscv32imc_build
 
 # Helper functions

--- a/utils/toolchain/build_riscv_toolchain.sh
+++ b/utils/toolchain/build_riscv_toolchain.sh
@@ -14,7 +14,6 @@ RISCV_GNU_TOOLCHAIN_SHA=afcc8bc655d30cf6af054ac1d3f5f89d0627aa79
 BUILDROOT_SHA=d6fa6a45e196665d6607b522f290b1451b949c2c
 
 DEFAULT_TARGET_DIR="/opt/riscv"
-SRC_MIRROR="http://espdev.cs.columbia.edu/stuff/riscv"
 TMP=/tmp/_riscv_build
 
 # Helper functions


### PR DESCRIPTION
The Leon3 toolchain script downloads some prebuilt files from espdev.cs.columbia.edu.
Starting March 23 2021 the server can only accept a secure connection with SSL encryption.
This PR updates the corresponding URL to us `https` and closes issue #96.