### PR TITLE
Patch Spandex wrapper for ATOP

### DIFF
--- a/rtl/caches/l2_wrapper.vhd
+++ b/rtl/caches/l2_wrapper.vhd
@@ -2526,7 +2526,7 @@ end process fsm_fwd_out;
 
       -- STORE ACK
       when send_wr_ack =>
-        if reg.cpu_msg /= CPU_WRITE_ATOM or bresp_valid = '1' then
+        if reg.cpu_msg /= CPU_WRITE_ATOM or bresp_valid = '1' or unsigned(xreg.atop) > 0 then
             somi.b.valid <= '1';
         end if;
 
@@ -2534,12 +2534,13 @@ end process fsm_fwd_out;
             somi.b.resp <= bresp_data;
         end if;
         
-        if mosi.b.ready = '1' and (reg.cpu_msg /= CPU_WRITE_ATOM or bresp_valid = '1') then
+        if mosi.b.ready = '1' and (reg.cpu_msg /= CPU_WRITE_ATOM or bresp_valid = '1' or unsigned(xreg.atop) > 0) then
         
           if unsigned(xreg.atop) > 0 then
             reg.state := load_rsp;
+          else
 
-          elsif valid_axi_req = '1' then
+            if valid_axi_req = '1' then
             if mosi.aw.valid = '0' then
               reg.cpu_msg := '0' & mosi.ar.lock;
               reg.hsize   := mosi.ar.size;
@@ -2624,8 +2625,7 @@ end process fsm_fwd_out;
           cpu_req_data_dcs     <= reg.dcs;
           cpu_req_data_pred_cid<= reg.pred_cid;
 
-        
-          --reg.state := idle;
+          end if;
 
         end if;
 

--- a/rtl/caches/l2_wrapper.vhd
+++ b/rtl/caches/l2_wrapper.vhd
@@ -2526,7 +2526,7 @@ end process fsm_fwd_out;
 
       -- STORE ACK
       when send_wr_ack =>
-        if reg.cpu_msg /= CPU_WRITE_ATOM or bresp_valid = '1' or unsigned(xreg.atop) > 0 then
+        if reg.cpu_msg /= CPU_WRITE_ATOM or bresp_valid = '1' then
             somi.b.valid <= '1';
         end if;
 
@@ -2534,7 +2534,7 @@ end process fsm_fwd_out;
             somi.b.resp <= bresp_data;
         end if;
         
-        if mosi.b.ready = '1' and (reg.cpu_msg /= CPU_WRITE_ATOM or bresp_valid = '1' or unsigned(xreg.atop) > 0) then
+        if mosi.b.ready = '1' and (reg.cpu_msg /= CPU_WRITE_ATOM or bresp_valid = '1') then
         
           if unsigned(xreg.atop) > 0 then
             reg.state := load_rsp;


### PR DESCRIPTION
Spandex handles ATOPs directly and guarantees success. So, in AXI AW channel, after a successful transaction, L2 wrapper needs to get the ATOP response from the Spandex L2 cache and pass it to the core.
In ESP there is currently no direct ATOP handling, so `xreg.atop` will be tied to `0`. Thus, all the original ESP state transitions are placed in the `else` block.