### PR TITLE
Release [2021.1.1]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Calendar Versioning](https://calver.org/) with format
 `YYYY.MINOR.MICRO`.
 
+## [2021.1.1]
+
+### Added
+
+- **Ibex**
+        - Enable ESP cache hierarchy with Ibex core (#92)
+
+### Fixed
+
+- **Toolchain scripts**
+        - Update URL of Leon3 prebuilt files (#96)
+
+- **Cache hierarchy**
+        - Fix endianness of the SystemC implementation for instances of ESP using a RISC-V core (#92)
+
+- **Ibex**
+        - Use Xilinx primitives for Ibex implementation on FPGA
+        - Disable ESP L2 invalidation master port on AHB bus (#92)
+
+- **Infrastructure*
+        - Fix link update of the object dump used in full-system RTL simulations (#93)
+        - Save HLS log files for the cache hierarchy into log folder
+        - Restore optimized floorplanning for proFPGA XCVU440 (#94)
+
+
 ## [2021.1.0]
 
 ### Added

--- a/rtl/caches/cachepackage.vhd
+++ b/rtl/caches/cachepackage.vhd
@@ -157,6 +157,7 @@ package cachepackage is
       tech        : integer := virtex7;
       sets        : integer := 256;
       ways        : integer := 8;
+      little_end  : integer range 0 to 1 := 1;
       hindex_mst  : integer := 0;
       pindex      : integer range 0 to NAPBSLV - 1 := 6;
       pirq        : integer := 4;
@@ -214,6 +215,7 @@ package cachepackage is
       tech        : integer := virtex7;
       sets        : integer := 256;
       ways        : integer := 8;
+      little_end  : integer range 0 to 1 := 1;
       mem_num     : integer := 1;
       mem_info    : tile_mem_info_vector(0 to MEM_ID_RANGE_MSB);
       cache_y     : yx_vec(0 to 2**NL2_MAX_LOG2 - 1);

--- a/rtl/caches/gencaches.vhd
+++ b/rtl/caches/gencaches.vhd
@@ -13,6 +13,7 @@ package gencaches is
   component l2
     generic (
       use_rtl : integer;
+      little_end : integer range 0 to 1;
       sets : integer;
       ways : integer
       );

--- a/rtl/caches/l2_acc_wrapper.vhd
+++ b/rtl/caches/l2_acc_wrapper.vhd
@@ -34,6 +34,7 @@ entity l2_acc_wrapper is
     tech        : integer := virtex7;
     sets        : integer := 256;
     ways        : integer := 8;
+    little_end  : integer range 0 to 1 := 1;
     mem_num     : integer := 1;
     mem_info    : tile_mem_info_vector(0 to MEM_ID_RANGE_MSB);
     cache_y     : yx_vec(0 to 2**NL2_MAX_LOG2 - 1);
@@ -383,6 +384,7 @@ begin  -- architecture rtl of l2_acc_wrapper
 
     generic map (
       use_rtl => CFG_CACHE_RTL,
+      little_end => little_end,
       sets => sets,
       ways => ways)
 

--- a/rtl/caches/l2_wrapper.vhd
+++ b/rtl/caches/l2_wrapper.vhd
@@ -36,6 +36,7 @@ entity l2_wrapper is
     hindex_mst  : integer := 0;
     pindex      : integer range 0 to NAPBSLV - 1 := 6;
     pirq        : integer := 4;
+    little_end  : integer range 0 to 1 := 1;
     mem_hindex  : integer := 4;
     mem_hconfig : ahb_config_type;
     mem_num     : integer := 1;
@@ -491,6 +492,7 @@ begin  -- architecture rtl of l2_wrapper
   l2_cache_i : l2
     generic map (
       use_rtl => CFG_CACHE_RTL,
+      little_end => little_end,
       sets => sets,
       ways => ways)
     port map (

--- a/rtl/caches/llc_wrapper.vhd
+++ b/rtl/caches/llc_wrapper.vhd
@@ -704,7 +704,7 @@ begin  -- architecture rtl
     ahbmo.hsize <= HSIZE_DWORD;
   end generate ariane_cache_word_gen;
 
-  leon3_cache_word_gen: if GLOB_CPU_ARCH = leon3 generate
+  leon3_cache_word_gen: if GLOB_CPU_ARCH = leon3 or GLOB_CPU_ARCH = ibex generate
     ahbmo.hsize <= HSIZE_WORD;
   end generate leon3_cache_word_gen;
 

--- a/rtl/tiles/tile_cpu.vhd
+++ b/rtl/tiles/tile_cpu.vhd
@@ -1208,6 +1208,7 @@ begin
         tech          => CFG_FABTECH,
         sets          => CFG_L2_SETS,
         ways          => CFG_L2_WAYS,
+        little_end    => GLOB_CPU_RISCV,
         hindex_mst    => CFG_NCPU_TILE,
         pindex        => 1,
         pirq          => CFG_SLD_L2_CACHE_IRQ,

--- a/tools/socgen/socmap_gen.py
+++ b/tools/socgen/socmap_gen.py
@@ -1968,9 +1968,10 @@ def print_cache_config(fp, soc, esp_config):
     addr_bits = 32
     byte_bits = 3
     word_bits = 1
-    fp.write("`define LITTLE_ENDIAN\n")
-  else: 
+  if soc.CPU_ARCH.get() == "leon3":
     fp.write("`define BIG_ENDIAN\n")
+  else:
+    fp.write("`define LITTLE_ENDIAN\n")
 
   fp.write("`define ADDR_BITS    " + str(addr_bits) + "\n")
   fp.write("`define BYTE_BITS    " + str(byte_bits) + "\n")

--- a/tools/socketgen/templates/noc2axi_interface.vhd
+++ b/tools/socketgen/templates/noc2axi_interface.vhd
@@ -37,6 +37,7 @@ use std.textio.all;
     scatter_gather : integer := 1;
     sets           : integer := 256;
     ways           : integer := 8;
+    little_end     : integer range 0 to 1 := 1;
     cache_tile_id  : cache_attribute_array;
     cache_y        : yx_vec(0 to 2**NL2_MAX_LOG2 - 1);
     cache_x        : yx_vec(0 to 2**NL2_MAX_LOG2 - 1);

--- a/tools/socketgen/templates/noc_interface.vhd
+++ b/tools/socketgen/templates/noc_interface.vhd
@@ -35,6 +35,7 @@ use std.textio.all;
     scatter_gather : integer := 1;
     sets           : integer := 256;
     ways           : integer := 8;
+    little_end     : integer range 0 to 1 := 1;
     cache_tile_id  : cache_attribute_array;
     cache_y        : yx_vec(0 to 2**NL2_MAX_LOG2 - 1);
     cache_x        : yx_vec(0 to 2**NL2_MAX_LOG2 - 1);
@@ -272,6 +273,7 @@ begin
         tech          => tech,
         sets          => sets,
         ways          => ways,
+        little_end    => little_end,
         mem_num       => cacheable_mem_num,
         mem_info      => cacheable_mem_info,
         cache_y       => cache_y,

--- a/tools/socketgen/templates/tile_acc.vhd
+++ b/tools/socketgen/templates/tile_acc.vhd
@@ -275,7 +275,9 @@ architecture rtl of tile_acc is
   constant io_x                : local_yx                           := tile_x(io_tile_id);
   constant this_scatter_gather : integer range 0 to 1               := CFG_SCATTER_GATHER;
 
-   -- Noc signals
+  constant little_end          : integer range 0 to 1               := GLOB_CPU_RISCV;
+
+  -- Noc signals
   signal noc1_stop_in_s         : std_logic_vector(4 downto 0);
   signal noc1_stop_out_s        : std_logic_vector(4 downto 0);
   signal noc1_acc_stop_in       : std_ulogic;

--- a/utils/flist/ibex_vlog.flist
+++ b/utils/flist/ibex_vlog.flist
@@ -27,3 +27,4 @@ dv/uvm/core_ibex/common/prim/prim_pkg.sv
 dv/uvm/core_ibex/common/prim/prim_clock_gating.sv
 vendor/lowrisc_ip/ip/prim_generic/rtl/prim_generic_clock_gating.sv
 shared/rtl/timer.sv
+vendor/lowrisc_ip/ip/prim_xilinx/rtl/prim_xilinx_clock_gating.sv

--- a/utils/make/accelerators.mk
+++ b/utils/make/accelerators.mk
@@ -365,7 +365,7 @@ SOCKETGEN_DEPS += $(ESP_CFG_BUILD)/socmap.vhd $(ESP_CFG_BUILD)/esp_global.vhd
 ### ESP Wrappers ###
 socketgen: $(SOCKETGEN_DEPS)
 	$(QUIET_MKDIR) $(RM) $@; mkdir -p $@
-	$(QUIET_RUN)$(ESP_ROOT)/tools/socketgen/socketgen.py $(NOC_WIDTH) $(ESP_ROOT)/tech/$(TECHLIB) $(ESP_ROOT)/accelerators/third-party $(ESP_ROOT)/tools/socketgen/templates ./socketgen
+	$(QUIET_RUN)$(ESP_ROOT)/tools/socketgen/socketgen.py $(NOC_WIDTH) $(CPU_ARCH) $(ESP_ROOT)/tech/$(TECHLIB) $(ESP_ROOT)/accelerators/third-party $(ESP_ROOT)/tools/socketgen/templates ./socketgen
 	@touch $@
 
 socketgen-clean:

--- a/utils/make/genus.mk
+++ b/utils/make/genus.mk
@@ -7,6 +7,7 @@ GENUS_EXCLUDE_VLOG += $(ESP_ROOT)/rtl/cores/ariane/ariane/src/util/ex_trace_item
 GENUS_EXCLUDE_VLOG += $(ESP_ROOT)/rtl/cores/ariane/ariane/src/util/instr_trace_item.svh
 GENUS_EXCLUDE_VLOG += $(ESP_ROOT)/rtl/cores/ariane/ariane/src/util/instr_tracer_if.sv
 GENUS_EXCLUDE_VLOG += $(ESP_ROOT)/rtl/cores/ariane/ariane/src/util/instr_tracer.sv
+GENUS_EXCLUDE_VLOG += $(ESP_ROOT)/rtl/cores/ibex/ibex/vendor/lowrisc_ip/ip/prim_xilinx/rtl/prim_xilinx_clock_gating.sv
 
 GENUS_EXCLUDE_VHDL += $(ESP_ROOT)/rtl/sockets/monitor/monitor.vhd
 GENUS_EXCLUDE_VHDL += $(DESIGN_PATH)/fpga_proxy_top.vhd

--- a/utils/make/ibex.mk
+++ b/utils/make/ibex.mk
@@ -148,6 +148,10 @@ VLOGOPT += -suppress 13262
 VLOGOPT += -suppress 2286
 VLOGOPT += -permissive
 VLOGOPT += +define+WT_DCACHE
+ifneq ($(filter $(TECHLIB),$(FPGALIBS)),)
+# use Xilinx-based primitives for FPGA
+VLOGOPT += +define+PRIM_DEFAULT_IMPL=prim_pkg::ImplXilinx
+endif
 VLOGOPT += -pedanticerrors
 VLOGOPT += -suppress 2583
 VLOGOPT += -suppress 13314

--- a/utils/make/modelsim.mk
+++ b/utils/make/modelsim.mk
@@ -102,12 +102,6 @@ endif
 	@cd modelsim; \
 	echo $(SPACES)"vmake > vsim.mk"; \
 	vmake 2> /dev/null > vsim.mk; \
-	if ! test -e prom.srec; then \
-		ln -s $(SOFT_BUILD)/prom.srec; \
-	fi; \
-	if ! test -e ram.srec; then \
-		ln -s $(SOFT_BUILD)/ram.srec; \
-	fi; \
 	cd ../;
 
 sim-compile: socketgen check_all_srcs modelsim/vsim.mk soft
@@ -115,6 +109,10 @@ sim-compile: socketgen check_all_srcs modelsim/vsim.mk soft
 		cp $$dat modelsim; \
 	done;
 	$(QUIET_MAKE)make -C modelsim -f vsim.mk
+	@cd modelsim; \
+	rm -f prom.srec ram.srec; \
+	ln -s $(SOFT_BUILD)/prom.srec; \
+	ln -s $(SOFT_BUILD)/ram.srec;
 
 sim: sim-compile
 	@cd modelsim; \

--- a/utils/make/ncsim.mk
+++ b/utils/make/ncsim.mk
@@ -94,12 +94,6 @@ endif
 		echo $(SPACES)"$(NCLOG) $$rtl"; \
 		$(NCLOG) -work work $$rtl || exit; \
 	done; \
-	if ! test -e prom.srec; then \
-		ln -s $(SOFT_BUILD)/prom.srec; \
-	fi; \
-	if ! test -e ram.srec; then \
-		ln -s $(SOFT_BUILD)/ram.srec; \
-	fi; \
 	echo $(SPACES)"$(NCELAB) $(SIMTOP) $(EXTRA_SIMTOP)"; \
 	$(NCELAB) $(SIMTOP) $(EXTRA_SIMTOP) && touch ncready; \
 	cd ../;
@@ -119,6 +113,10 @@ ncsim-compile: socketgen check_all_srcs soft incisive/ncready incisive/ncsim.in
 	echo $(SPACES)"$(NCUPDATE) $(SIMTOP)"; \
 	$(NCUPDATE) $(SIMTOP); \
 	cd ../;
+	@cd incisive; \
+	rm -f prom.srec ram.srec; \
+	ln -s $(SOFT_BUILD)/prom.srec; \
+	ln -s $(SOFT_BUILD)/ram.srec;
 
 ncsim: ncsim-compile
 	@cd incisive; \

--- a/utils/make/sc_caches.mk
+++ b/utils/make/sc_caches.mk
@@ -13,7 +13,7 @@ print-available-sccs:
 	$(QUIET_INFO)echo "Available sccs: $(SCCS)"
 
 
-$(SCCS-wdir):
+$(SCCS-wdir): $(HLS_LOGS)
 	$(QUIET_MKDIR)mkdir -p $(SCCS_PATH)/$(@:-wdir=)/hls-work-$(TECHLIB)
 	@cd $(SCCS_PATH)/$(@:-wdir=)/hls-work-$(TECHLIB); \
 	if test ! -e project.tcl; then \
@@ -24,9 +24,9 @@ $(SCCS-wdir):
 	fi;
 
 $(SCCS-hls): %-hls : %-wdir
-	$(QUIET_MAKE)COMPONENT=$(@:-hls=) TECH=$(TECHLIB) ESP_ROOT=$(ESP_ROOT) make -C $(SCCS_PATH)/$(@:-hls=)/hls-work-$(TECHLIB) memlib | tee $(@:-hls=)_memgen.log
+	$(QUIET_MAKE)COMPONENT=$(@:-hls=) TECH=$(TECHLIB) ESP_ROOT=$(ESP_ROOT) make -C $(SCCS_PATH)/$(@:-hls=)/hls-work-$(TECHLIB) memlib | tee $(HLS_LOGS)/$(@:-hls=)_memgen.log
 	$(QUIET_INFO)echo "Running HLS for available implementations of $(@:-hls=)"
-	$(QUIET_MAKE)COMPONENT=$(@:-hls=) TECH=$(TECHLIB) ESP_ROOT=$(ESP_ROOT) make -C $(SCCS_PATH)/$(@:-hls=)/hls-work-$(TECHLIB) hls_all | tee $(@:-hls=)_hls.log
+	$(QUIET_MAKE)COMPONENT=$(@:-hls=) TECH=$(TECHLIB) ESP_ROOT=$(ESP_ROOT) make -C $(SCCS_PATH)/$(@:-hls=)/hls-work-$(TECHLIB) hls_all | tee $(HLS_LOGS)/$(@:-hls=)_hls.log
 	$(QUIET_INFO)echo "Installing available implementations for $(@:-hls=) to $(ESP_ROOT)/tech/$(TECHLIB)/sccs/$(@:-hls=)"
 	$(QUIET_MAKE)COMPONENT=$(@:-hls=) TECH=$(TECHLIB) ESP_ROOT=$(ESP_ROOT) make -C $(SCCS_PATH)/$(@:-hls=)/hls-work-$(TECHLIB) install
 	@if test -e $(ESP_ROOT)/tech/$(TECHLIB)/sccs/installed.log; then \
@@ -35,15 +35,15 @@ $(SCCS-hls): %-hls : %-wdir
 	@echo "$(@:-hls=)" >> $(ESP_ROOT)/tech/$(TECHLIB)/sccs/installed.log
 
 $(SCCS-sim): %-sim : %-wdir
-	$(QUIET_RUN)COMPONENT=$(@:-sim=) TECH=$(TECHLIB) ESP_ROOT=$(ESP_ROOT) make -C $(SCCS_PATH)/$(@:-sim=)/hls-work-$(TECHLIB) sim_all | tee $(@:-sim=)_sim.log
+	$(QUIET_RUN)COMPONENT=$(@:-sim=) TECH=$(TECHLIB) ESP_ROOT=$(ESP_ROOT) make -C $(SCCS_PATH)/$(@:-sim=)/hls-work-$(TECHLIB) sim_all | tee $(HLS_LOGS)/$(@:-sim=)_sim.log
 
 $(SCCS-clean): %-clean : %-wdir
 	$(QUIET_CLEAN)COMPONENT=$(@:-clean=) TECH=$(TECHLIB) ESP_ROOT=$(ESP_ROOT) make -C $(SCCS_PATH)/$(@:-clean=)/hls-work-$(TECHLIB) clean
-	@$(RM) $(@:-clean=)*.log
+	@$(RM) $(HLS_LOGS)/$(@:-clean=)*.log
 
 $(SCCS-distclean): %-distclean : %-wdir
 	$(QUIET_CLEAN)COMPONENT=$(@:-distclean=) TECH=$(TECHLIB) ESP_ROOT=$(ESP_ROOT) make -C $(SCCS_PATH)/$(@:-distclean=)/hls-work-$(TECHLIB) distclean
-	@$(RM) $(@:-distclean=)*.log
+	@$(RM) $(HLS_LOGS)/$(@:-distclean=)*.log
 	@if test -e $(ESP_ROOT)/tech/$(TECHLIB)/sccs/installed.log; then \
 		sed -i '/$(@:-distclean=)/d' $(ESP_ROOT)/tech/$(TECHLIB)/sccs/installed.log; \
 	fi;

--- a/utils/make/vivado.mk
+++ b/utils/make/vivado.mk
@@ -67,7 +67,11 @@ vivado/setup.tcl: vivado $(XDC) $(BOARD_FILES)
 	@echo "create_project $(DESIGN) -part ${DEVICE} -force" > $@
 	@echo "set_property target_language verilog [current_project]" >> $@
 	@echo "set_property include_dirs {$(INCDIR)} [get_filesets {sim_1 sources_1}]" >> $@
+ifeq ("$(CPU_ARCH)","ibex")
+	@echo "set_property verilog_define {XILINX_FPGA=1 WT_DCACHE=1 PRIM_DEFAULT_IMPL=prim_pkg::ImplXilinx} [get_filesets {sim_1 sources_1}]" >> $@
+else
 	@echo "set_property verilog_define {XILINX_FPGA=1 WT_DCACHE=1} [get_filesets {sim_1 sources_1}]" >> $@
+endif
 	@echo "source ./srcs.tcl" >> $@
 ifneq ("$(PROTOBOARD)","")
 	@echo "set_property board_part $(PROTOBOARD) [current_project]"  >> $@

--- a/utils/make/vivado.mk
+++ b/utils/make/vivado.mk
@@ -132,10 +132,10 @@ endif
 	@if test -r $(UTILS_GRLIB)/netlists/$(TECHLIB); then \
 		echo "import_files $(UTILS_GRLIB)/netlists/$(TECHLIB)" >> $@; \
 	fi;
-	@if test -r $(DESIGN_PATH)/mem_tile_floorplanning.xdc; then \
-		echo "read_xdc  $(DESIGN_PATH)/mem_tile_floorplanning.xdc" >> $@; \
-	    echo "set_property used_in_synthesis true [get_files $(DESIGN_PATH)/mem_tile_floorplanning.xdc]" >> $@; \
-	    echo "set_property used_in_implementation true [get_files $(DESIGN_PATH)/mem_tile_floorplanning.xdc]" >> $@; \
+	@if test -r $(DESIGN_PATH)/socgen/esp/mem_tile_floorplanning.xdc; then \
+		echo "read_xdc  $(DESIGN_PATH)/socgen/esp/mem_tile_floorplanning.xdc" >> $@; \
+	    echo "set_property used_in_synthesis true [get_files $(DESIGN_PATH)/socgen/esp/mem_tile_floorplanning.xdc]" >> $@; \
+	    echo "set_property used_in_implementation true [get_files $(DESIGN_PATH)/socgen/esp/mem_tile_floorplanning.xdc]" >> $@; \
 	echo "set_property strategy Congestion_SpreadLogic_high [get_runs impl_1]" >> $@; \
 	fi;
 	@for i in $(XDC); do \
@@ -277,7 +277,6 @@ vivado-clean:
 vivado-distclean: vivado-clean
 	$(QUIET_CLEAN)$(RM) \
 		vivado	\
-		mem_tile_floorplanning.xdc \
 		*.bit
 
 .PHONY: vivado-clean vivado-distclean vivado-syn vivado-prog-fpga vivado/$(DESIGN) vivado-setup vivado-gui

--- a/utils/make/xmsim.mk
+++ b/utils/make/xmsim.mk
@@ -96,12 +96,6 @@ endif
 		echo $(SPACES)"$(XMLOG) -work work $$rtl"; \
 		$(XMLOG) -work work $$rtl || exit; \
 	done; \
-	if ! test -e prom.srec; then \
-		ln -s $(SOFT_BUILD)/prom.srec; \
-	fi; \
-	if ! test -e ram.srec; then \
-		ln -s $(SOFT_BUILD)/ram.srec; \
-	fi; \
 	echo $(SPACES)"$(XMELAB) $(SIMTOP) $(EXTRA_SIMTOP)"; \
 	$(XMELAB) $(SIMTOP) $(EXTRA_SIMTOP) && touch xmready; \
 	cd ../;
@@ -118,6 +112,10 @@ xmsim-compile: socketgen check_all_srcs soft xcelium/xmready xcelium/xmsim.in
 	echo $(SPACES)"$(XMUPDATE) $(SIMTOP)"; \
 	$(XMUPDATE) $(SIMTOP); \
 	cd ../;
+	@cd xcelium; \
+	rm -f prom.srec ram.srec; \
+	ln -s $(SOFT_BUILD)/prom.srec; \
+	ln -s $(SOFT_BUILD)/ram.srec;
 
 xmsim: xmsim-compile
 	@cd xcelium; \


### PR DESCRIPTION
## [2021.1.1]

### Added

- **Ibex**
        - Enable ESP cache hierarchy with Ibex core (#92)

### Fixed

- **Cache hierarchy**
        - Fix endianness of the SystemC implementation for instances of ESP using a RISC-V core (#92)

- **Ibex**
        - Use Xilinx primitives for Ibex implementation on FPGA
        - Disable ESP L2 invalidation master port on AHB bus (#92)

- **Infrastructure*
        - Fix link update of the object dump used in full-system RTL simulations (#93)
        - Save HLS log files for the cache hierarchy into log folder
        - Restore optimized floorplanning for proFPGA XCVU440 (#94)