### PR TITLE
Update submodule for riscv-pk (upstream + apbuart)

### DIFF
--- a/soft/common/drivers/baremetal/probe/fdt.c
+++ b/soft/common/drivers/baremetal/probe/fdt.c
@@ -34,9 +34,14 @@
 
 static inline uint32_t bswap(uint32_t x)
 {
+// #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
   uint32_t y = (x & 0x00FF00FF) <<  8 | (x & 0xFF00FF00) >>  8;
   uint32_t z = (y & 0x0000FFFF) << 16 | (y & 0xFFFF0000) >> 16;
   return z;
+// #else
+//   /* No need to swap on big endian */
+//   return x;
+// #endif
 }
 
 static inline int isstring(char c)
@@ -75,7 +80,7 @@ static uint32_t *fdt_scan_helper(
         break;
       }
       case FDT_PROP: {
-        /* assert (!last); */
+        // assert (!last);
         prop.name  = strings + bswap(lex[2]);
         prop.len   = bswap(lex[1]);
         prop.value = lex + 3;
@@ -151,6 +156,11 @@ const uint32_t *fdt_get_size(const struct fdt_scan_node *node, const uint32_t *v
   return value;
 }
 
+uint32_t fdt_get_value(const struct fdt_scan_prop *prop, uint32_t index)
+{
+  return bswap(prop->value[index]);
+}
+
 int fdt_string_list_index(const struct fdt_scan_prop *prop, const char *str)
 {
   const char *list = (const char *)prop->value;
@@ -162,10 +172,4 @@ int fdt_string_list_index(const struct fdt_scan_prop *prop, const char *str)
     list += strlen(list) + 1;
   }
   return -1;
-}
-
-const uint32_t *fdt_get_value(const uint32_t *value, uint32_t *result)
-{
-  *result = bswap(*value++);
-  return value;
 }

--- a/soft/common/drivers/baremetal/probe/probe.c
+++ b/soft/common/drivers/baremetal/probe/probe.c
@@ -223,7 +223,7 @@ static void esp_prop(const struct fdt_scan_prop *prop, void *extra)
 	else if (!strcmp(prop->name, "reg"))
 		fdt_get_address(prop->node->parent, prop->value, (uint64_t *) &(*espdevs)[ndev].addr);
 	else if (!strcmp(prop->name, "interrupts"))
-		fdt_get_value(prop->value, (uint32_t *) &(*espdevs)[ndev].irq);
+		(*espdevs)[ndev].irq = fdt_get_value(prop, 0); // TODO sending proper index instead of always 0
 }
 
 static void esp_done(const struct fdt_scan_node *node, void *extra)


### PR DESCRIPTION
:zap: Update riscv-pk submodule
- update riscv-pk submodule to commit ` e8e6b3a` from May 18, 2021
- re-apply APB UART patch
- update the bare-metal probe library to match the updated riscv-pk submodule