### PR TITLE
Add basic RTL accelerator design flow

### DIFF
--- a/accelerators/rtl/common/common.mk
+++ b/accelerators/rtl/common/common.mk
@@ -1,0 +1,66 @@
+# Copyright (c) 2011-2021 Columbia University, System Level Design Group
+# SPDX-License-Identifier: Apache-2.0
+
+### Some pretty aliases ###
+
+# Define V=1 for a more verbose compilation
+ifndef V
+	QUIET_AR            = @echo '   ' AR $@;
+	QUIET_AS            = @echo '   ' AS $@;
+	QUIET_BUILD         = @echo '   ' BUILD $@;
+	QUIET_CHMOD         = @echo '   ' CHMOD $@;
+	QUIET_CC            = @echo '   ' CC $@;
+	QUIET_CXX           = @echo '   ' CXX $@;
+	QUIET_OBJCP         = @echo '   ' OBJCP $@;
+	QUIET_CHECKPATCH    = @echo '   ' CHECKPATCH $(subst .o,.c,$@);
+	QUIET_CHECK         = @echo '   ' CHECK $(subst .o,.c,$@);
+	QUIET_LINK          = @echo '   ' LINK $@;
+	QUIET_CP            = @echo '   ' CP $@;
+	QUIET_RM            = @echo '   ' RM $@;
+	QUIET_MKDIR         = @echo '   ' MKDIR $@;
+	QUIET_MAKE          = @echo '   ' MAKE $@;
+	QUIET_INFO          = @echo -n '   ' INFO '';
+	QUIET_DIFF          = @echo -n '   ' DIFF '';
+	QUIET_RUN           = @echo '   ' RUN $@;
+	QUIET_CLEAN         = @echo '   ' CLEAN $@;
+endif
+	SPACES              = "    "
+	SPACING             = echo -n "    ";
+
+RM  = rm -rf
+
+
+ifeq ("$(ESP_ROOT)","")
+$(error ESP_ROOT not set)
+endif
+
+ifeq ("$(TECH)","")
+$(error target technology TECH is not specified)
+endif
+
+ifeq ("$(ACCELERATOR)","")
+# ACCELERATOR is not set
+ifeq ("$(COMPONENT)","")
+$(error Either COMPONENT or ACCELERATOR must be set)
+endif
+
+else
+# ACCELERATOR is set
+ifneq ("$(COMPONENT)","")
+$(error Either COMPONENT or ACCELERATOR must be set)
+endif
+
+endif
+
+
+ifneq ("$(ACCELERATOR)","")
+TARGET_NAME = $(ACCELERATOR)
+else
+TARGET_NAME = $(COMPONENT)
+endif
+
+ifneq ("$(ACCELERATOR)","")
+RTL_OUT = $(ESP_ROOT)/tech/$(TECH)/acc/$(ACCELERATOR)
+else
+RTL_OUT = $(ESP_ROOT)/tech/$(TECH)/sccs/$(COMPONENT)
+endif

--- a/accelerators/rtl/common/hls/Makefile
+++ b/accelerators/rtl/common/hls/Makefile
@@ -1,0 +1,27 @@
+# Copyright (c) 2011-2021 Columbia University, System Level Design Group
+# SPDX-License-Identifier: Apache-2.0
+
+COMMON_PATH = $(ESP_ROOT)/accelerators/rtl/common
+COMMON_HLS_PATH = $(COMMON_PATH)/hls
+
+include $(COMMON_PATH)/common.mk
+
+install: 
+	@mkdir -p $(RTL_OUT)
+ifneq ("$(ACCELERATOR)","")
+	@NAME_SHORT=$(TARGET_NAME:_rtl=); \
+	cp ../$$NAME_SHORT.xml $(RTL_OUT)/$(TARGET_NAME).xml;
+endif
+	@NAME_SHORT=$(TARGET_NAME:_rtl=); \
+	cp -r ../src/* $(RTL_OUT)
+
+# Clean out undesirable junk files from the project directory
+# Uses the automatically created clean_all target from Makefile.prj
+clean:
+
+CLEAN: clean
+
+distclean: clean
+	@rm -rf $(RTL_OUT)
+
+.PHONY: install clean CLEAN distclean

--- a/tools/accgen/accgen.sh
+++ b/tools/accgen/accgen.sh
@@ -85,12 +85,13 @@ echo ""
 read -p "  * Enter accelerator name ${def}[${NAME_DEFAULT}]${normal}: " NAME
 NAME=${NAME:-$NAME_DEFAULT}
 
-read -p "  * Select design flow (${bold}S${normal}tratus HLS, ${bold}V${normal}ivado HLS, ${bold}h${normal}ls4ml) ${def}[S]${normal}: " FLOW_SELECT
+read -p "  * Select design flow (${bold}S${normal}tratus HLS, ${bold}V${normal}ivado HLS, ${bold}h${normal}ls4ml, ${bold}R${normal}TL) ${def}[S]${normal}: " FLOW_SELECT
 FLOW_SELECT=${FLOW_SELECT:-S}
 case $FLOW_SELECT in
     [Ss]* ) FLOW="stratus_hls" FLOWSUFFIX="stratus";;
     [Vv]* ) FLOW="vivado_hls" FLOWSUFFIX="vivado";;
     [Hh]* ) FLOW="hls4ml" FLOWSUFFIX="hls4ml";;
+    [Rr]* ) FLOW="rtl" FLOWSUFFIX="rtl";;
     * ) FLOW="stratus_hls" FLOWSUFFIX="stratus";;
 esac
 
@@ -111,6 +112,9 @@ if  test -e ${ESP_ROOT}/accelerators/vivado_hls/$NAMEFULL; then
     die "accelerator ${NAMEFULL} already defined"
 fi
 if  test -e ${ESP_ROOT}/accelerators/hls4ml/$NAMEFULL; then
+    die "accelerator ${NAMEFULL} already defined"
+fi
+if  test -e ${ESP_ROOT}/accelerators/rtl/$NAMEFULL; then
     die "accelerator ${NAMEFULL} already defined"
 fi
 
@@ -146,6 +150,7 @@ if [ $FLOW != "hls4ml" ]; then
 
 	values+=( ["$param"]=$val )
 	maxs+=( ["$param"]=$max )
+
 	NPARAMS=$((NPARAMS+1))
 
 	if [ $NPARAMS == 14 ]; then
@@ -270,7 +275,6 @@ memory_footprint=$(( memory_words * (data_width/8) ))
 TLB_ENTRIES=$(( (memory_footprint + 1048575) / 1048576 ))
 if (( $TLB_ENTRIES < 4 )); then TLB_ENTRIES=4; fi;
 
-
 ### Generate accelerator skeleton
 CURR_DIR=${PWD}
 cd $ESP_ROOT
@@ -300,34 +304,50 @@ elif [ "$FLOW" == "hls4ml" ]; then
 
     dirs="src  inc  hls  tb"
 
+elif [ "$FLOW" == "rtl" ]; then
+    dirs="src hls"
 fi
 
 ## initialize all design folders
 for d in $dirs; do
     mkdir -p $ACC_DIR/hw/$d
     cd $ACC_DIR/hw/$d
-    cp $TEMPLATES_DIR/$d/* .
-
+    if ! [[ "$FLOW" == "rtl" && "$d" == "hls" ]]; then
+	cp -r $TEMPLATES_DIR/$d/* .
+    fi
+    
     if cat /etc/os-release | grep -q -i ubuntu; then
         rename "s/accelerator/$LOWER/g" *
 	rename "s/acc_full/$LOWERFULL/g" *
+        rename "s/accelerator/$LOWER/g" */*
+	rename "s/acc_full/$LOWERFULL/g" */*
     elif cat /etc/os-release | grep -q -i centos; then
         rename accelerator $LOWER *
 	rename acc_full $LOWERFULL *
+        rename accelerator $LOWER */*
+	rename acc_full $LOWERFULL */*
     elif cat /etc/os-release | grep -q -i rhel; then
         rename accelerator $LOWER *
 	rename acc_full $LOWERFULL *
+        rename accelerator $LOWER */*
+	rename acc_full $LOWERFULL */*
     fi
-
-    sed -i "s/<accelerator_name>/$LOWER/g" *
-    sed -i "s/<ACCELERATOR_NAME>/$UPPER/g" *
-    sed -i "s/<acc_full_name>/$LOWERFULL/g" *
-    sed -i "s/<ACC_FULL_NAME>/$UPPERFULL/g" *
+    
+    if [[ "$FLOW" == "rtl" && "$d" != "hls" ]]; then
+	sed -i "s/<accelerator_name>/$LOWER/g" */*
+	sed -i "s/<ACCELERATOR_NAME>/$UPPER/g" */*
+	sed -i "s/<acc_full_name>/$LOWERFULL/g" */*
+	sed -i "s/<ACC_FULL_NAME>/$UPPERFULL/g" */*
+    elif [ "$FLOW" != "rtl" ]; then
+	sed -i "s/<accelerator_name>/$LOWER/g" *
+	sed -i "s/<ACCELERATOR_NAME>/$UPPER/g" *
+	sed -i "s/<acc_full_name>/$LOWERFULL/g" *
+	sed -i "s/<ACC_FULL_NAME>/$UPPERFULL/g" *
+    fi
 
     if [[ "$FLOW" == "stratus_hls" && "$d" == "hls" ]]; then
 	ln -s ../../../common/hls/Makefile
     fi
-
     if [[ "$FLOW" == "vivado_hls" && "$d" == "hls" ]]; then
 	ln -s ../../../common/hls/Makefile
 	ln -s ../../../common/hls/common.tcl
@@ -335,6 +355,9 @@ for d in $dirs; do
     if [[ "$FLOW" == "hls4ml" && "$d" == "hls" ]]; then
 	ln -s ../../../common/hls/Makefile
 	ln -s ../../../common/hls/common.tcl
+    fi
+    if [[ "$FLOW" == "rtl" && "$d" == "hls" ]]; then
+	ln -s ../../../common/hls/Makefile
     fi
 done
 
@@ -396,6 +419,18 @@ if [ "$FLOW" == "stratus_hls" ]; then
     done
 fi
 
+indent="\ \ \ "
+if [ "$FLOW" == "rtl" ]; then
+    cd $ACC_DIR/hw/src
+    sep=","
+    for key in ${!values[@]}; do
+	sed -i "/\/\* <<--params-list-->> \*\//a conf_info_${key}${sep}" ${LOWERFULL}_basic_dma32/${LOWERFULL}_basic_dma32.v
+	sed -i "/\/\* <<--params-list-->> \*\//a conf_info_${key}${sep}" ${LOWERFULL}_basic_dma64/${LOWERFULL}_basic_dma64.v
+	sed -i "/\/\* <<--params-def-->> \*\//a ${indent}input [31:0]  conf_info_${key};" ${LOWERFULL}_basic_dma32/${LOWERFULL}_basic_dma32.v
+	sed -i "/\/\* <<--params-def-->> \*\//a ${indent}input [31:0]  conf_info_${key};" ${LOWERFULL}_basic_dma64/${LOWERFULL}_basic_dma64.v
+    done
+fi
+indent="\ \ \ \ \ \ \ \ "
 
 ## PLM memories for both 32-bit and 64-bit NoC
 dma_width=(32 64)

--- a/tools/accgen/templates/drivers/baremetal/accelerator.c
+++ b/tools/accgen/templates/drivers/baremetal/accelerator.c
@@ -142,7 +142,7 @@ int main(int argc, char * argv[])
 		printf("  nchunk = %lu\n", NCHUNK(mem_size));
 
 #ifndef __riscv
-		for (coherence = ACC_COH_NONE; coherence <= ACC_COH_FULL; coherence++) {
+		for (coherence = ACC_COH_NONE; coherence <= ACC_COH_RECALL; coherence++) {
 #else
 		{
 			/* TODO: Restore full test once ESP caches are integrated */

--- a/tools/accgen/templates/drivers_hls4ml/baremetal/accelerator.c
+++ b/tools/accgen/templates/drivers_hls4ml/baremetal/accelerator.c
@@ -157,7 +157,7 @@ int main(int argc, char * argv[])
 		printf("  nchunk = %lu\n", NCHUNK(mem_size));
 
 #ifndef __riscv
-		for (coherence = ACC_COH_NONE; coherence <= ACC_COH_FULL; coherence++) {
+		for (coherence = ACC_COH_NONE; coherence <= ACC_COH_RECALL; coherence++) {
 #else
 		{
 			/* TODO: Restore full test once ESP caches are integrated */

--- a/tools/accgen/templates/rtl/src/acc_full_basic_dma32/acc_full_basic_dma32.v
+++ b/tools/accgen/templates/rtl/src/acc_full_basic_dma32/acc_full_basic_dma32.v
@@ -1,0 +1,45 @@
+module <acc_full_name>_basic_dma32( clk, rst, dma_read_chnl_valid, dma_read_chnl_data, dma_read_chnl_ready,
+/* <<--params-list-->> */
+conf_done, acc_done, debug, dma_read_ctrl_valid, dma_read_ctrl_data_index, dma_read_ctrl_data_length, dma_read_ctrl_data_size, dma_read_ctrl_ready, dma_write_ctrl_valid, dma_write_ctrl_data_index, dma_write_ctrl_data_length, dma_write_ctrl_data_size, dma_write_ctrl_ready, dma_write_chnl_valid, dma_write_chnl_data, dma_write_chnl_ready);
+
+   input clk;
+   input rst;
+
+   /* <<--params-def-->> */
+   input 	 conf_done;
+
+   input 	 dma_read_ctrl_ready;
+   output 	 dma_read_ctrl_valid;
+   output [31:0] dma_read_ctrl_data_index;
+   output [31:0] dma_read_ctrl_data_length;
+   output [2:0]  dma_read_ctrl_data_size;
+
+   output 	 dma_read_chnl_ready;
+   input 	 dma_read_chnl_valid;
+   input [31:0]  dma_read_chnl_data;
+
+   input 	 dma_write_ctrl_ready;
+   output 	 dma_write_ctrl_valid;
+   output [31:0] dma_write_ctrl_data_index;
+   output [31:0] dma_write_ctrl_data_length;
+   output [2:0]  dma_write_ctrl_data_size;
+
+   input 	 dma_write_chnl_ready;
+   output 	 dma_write_chnl_valid;
+   output [31:0] dma_write_chnl_data;
+
+   output 	 acc_done;
+   output [31:0] debug;
+
+   reg 		 acc_done;
+
+
+   assign dma_read_ctrl_valid = 1'b0;
+   assign dma_read_chnl_ready = 1'b1;
+   assign dma_write_ctrl_valid = 1'b0;
+   assign dma_write_chnl_valid = 1'b0;
+   assign debug = 32'd0;
+
+   assign acc_done = conf_done;
+   
+endmodule

--- a/tools/accgen/templates/rtl/src/acc_full_basic_dma64/acc_full_basic_dma64.v
+++ b/tools/accgen/templates/rtl/src/acc_full_basic_dma64/acc_full_basic_dma64.v
@@ -1,0 +1,44 @@
+module <acc_full_name>_basic_dma64( clk, rst, dma_read_chnl_valid, dma_read_chnl_data, dma_read_chnl_ready,
+/* <<--params-list-->> */
+conf_done, acc_done, debug, dma_read_ctrl_valid, dma_read_ctrl_data_index, dma_read_ctrl_data_length, dma_read_ctrl_data_size, dma_read_ctrl_ready, dma_write_ctrl_valid, dma_write_ctrl_data_index, dma_write_ctrl_data_length, dma_write_ctrl_data_size, dma_write_ctrl_ready, dma_write_chnl_valid, dma_write_chnl_data, dma_write_chnl_ready);
+
+   input clk;
+   input rst;
+
+   /* <<--params-def-->> */
+   input 	 conf_done;
+
+   input 	 dma_read_ctrl_ready;
+   output 	 dma_read_ctrl_valid;
+   output [31:0] dma_read_ctrl_data_index;
+   output [31:0] dma_read_ctrl_data_length;
+   output [2:0]  dma_read_ctrl_data_size;
+
+   output 	 dma_read_chnl_ready;
+   input 	 dma_read_chnl_valid;
+   input [63:0]  dma_read_chnl_data;
+
+   input 	 dma_write_ctrl_ready;
+   output 	 dma_write_ctrl_valid;
+   output [31:0] dma_write_ctrl_data_index;
+   output [31:0] dma_write_ctrl_data_length;
+   output [2:0]  dma_write_ctrl_data_size;
+
+   input 	 dma_write_chnl_ready;
+   output 	 dma_write_chnl_valid;
+   output [63:0] dma_write_chnl_data;
+
+   output 	 acc_done;
+   output [31:0] debug;
+
+   reg 		 acc_done;   
+
+   assign dma_read_ctrl_valid = 1'b0;
+   assign dma_read_chnl_ready = 1'b1;
+   assign dma_write_ctrl_valid = 1'b0;
+   assign dma_write_chnl_valid = 1'b0;
+   assign debug = 32'd0;
+
+   assign acc_done = conf_done;
+   
+endmodule

--- a/tools/socketgen/socketgen.py
+++ b/tools/socketgen/socketgen.py
@@ -1243,7 +1243,7 @@ def gen_tech_dep(accelerator_list, cache_list, dma_width, template_dir, out_dir)
       for acc in accelerator_list:
         for impl in acc.hlscfg:
           f.write("\n")
-          if acc.hls_tool == 'stratus_hls':
+          if acc.hls_tool == 'stratus_hls' or acc.hls_tool == 'rtl':
             f.write("  component " + acc.name + "_" + impl.name + "\n")
             f.write("    port (\n")
             write_acc_interface(f, acc, dma_width, impl.datatype, "rst", False, False, False)
@@ -1471,7 +1471,7 @@ def gen_tech_indep_impl(accelerator_list, cache_list, dma_width, template_dir, o
           for impl in acc.hlscfg:
             f.write("\n")
             f.write("  impl_" + impl.name + "_gen: if hls_conf = HLSCFG_" + acc.name.upper() + "_" + impl.name.upper() + " generate\n")
-            if acc.hls_tool == 'stratus_hls':
+            if acc.hls_tool == 'stratus_hls' or acc.hls_tool == 'rtl':
               f.write("    " + acc.name + "_" + impl.name + "_i: " + acc.name + "_" + impl.name + "\n")
               write_acc_port_map(f, acc, dma_width, impl.datatype, "rst", False, False, False, False)
             else:
@@ -1981,7 +1981,7 @@ for acc in accelerators:
       # hls4ml accelerators are implemented as Vivado HLS accelerators
       if accd.hls_tool in ('hls4ml'):
         accd.hls_tool = 'vivado_hls'
-      if not accd.hls_tool in ('stratus_hls', 'vivado_hls', 'catapult_hls_cxx', 'catapult_hls_sysc'):
+      if not accd.hls_tool in ('stratus_hls', 'vivado_hls', 'catapult_hls_cxx', 'catapult_hls_sysc', 'rtl'):
         print("    ERROR: Wrong HLS tool for " + acc)
         sys.exit(1)
 

--- a/utils/make/accelerators.mk
+++ b/utils/make/accelerators.mk
@@ -53,6 +53,14 @@ CHISEL_ACC_PATHS     = $(addprefix $(ESP_ROOT)/accelerators/chisel/, $(CHISEL_AC
 CHISEL_ACC-clean     = $(addsuffix -clean, $(CHISEL_ACC))
 CHISEL_ACC-distclean = $(addsuffix -distclean, $(CHISEL_ACC))
 
+RTL_ACC_PATH      = $(ESP_ROOT)/accelerators/rtl
+RTL_ACC           = $(filter-out common, $(shell ls -d $(RTL_ACC_PATH)/*/ | awk -F/ '{print $$(NF-1)}'))
+RTL_ACC_PATHS     = $(addprefix $(RTL_ACC_PATH)/, $(RTL_ACC))
+RTL_ACC-wdir      = $(addsuffix -wdir, $(RTL_ACC))
+RTL_ACC-hls       = $(addsuffix -hls, $(RTL_ACC))
+RTL_ACC-clean     = $(addsuffix -clean, $(RTL_ACC))
+RTL_ACC-distclean = $(addsuffix -distclean, $(RTL_ACC))
+
 THIRDPARTY_PATH = $(ESP_ROOT)/accelerators/third-party
 ifdef CPU_ARCH
 THIRDPARTY_ACC  = $(foreach acc, $(shell ls $(THIRDPARTY_PATH)), $(shell if grep -q $(CPU_ARCH) $(THIRDPARTY_PATH)/$(acc)/$(acc).hosts; then echo $(acc); fi))
@@ -69,20 +77,21 @@ THIRDPARTY_SVLOG      = $(foreach acc, $(THIRDPARTY_ACC), $(foreach rtl, $(shell
 THIRDPARTY_VHDL_PKGS  = $(foreach acc, $(THIRDPARTY_ACC), $(foreach rtl, $(shell strings $(THIRDPARTY_PATH)/$(acc)/$(acc).pkgs),     $(shell f=$(THIRDPARTY_PATH)/$(acc)/out/$(rtl); if test -e $$f; then echo $$f; fi;)))
 THIRDPARTY_VHDL       = $(foreach acc, $(THIRDPARTY_ACC), $(foreach rtl, $(shell strings $(THIRDPARTY_PATH)/$(acc)/$(acc).vhdl),     $(shell f=$(THIRDPARTY_PATH)/$(acc)/out/$(rtl); if test -e $$f; then echo $$f; fi;)))
 
-ACC_PATHS = $(STRATUSHLS_ACC_PATHS) $(VIVADOHLS_ACC_PATHS) $(CATAPULTHLS_ACC_PATHS) $(HLS4ML_ACC_PATHS) $(CHISEL_ACC_PATHS)
+ACC_PATHS = $(STRATUSHLS_ACC_PATHS) $(VIVADOHLS_ACC_PATHS) $(CATAPULTHLS_ACC_PATHS) $(HLS4ML_ACC_PATHS) $(CHISEL_ACC_PATHS) $(RTL_ACC_PATHS)
 
-ACC-driver       = $(addsuffix -driver, $(STRATUSHLS_ACC)) $(addsuffix -driver, $(VIVADOHLS_ACC)) $(addsuffix -driver, $(HLS4ML_ACC)) $(addsuffix -driver, $(CHISEL_ACC)) $(addsuffix -driver, $(CATAPULTHLS_ACC))
-ACC-driver-clean = $(addsuffix -driver-clean, $(STRATUSHLS_ACC)) $(addsuffix -driver-clean, $(VIVADOHLS_ACC)) $(addsuffix -driver-clean, $(HLS4ML_ACC)) $(addsuffix -driver-clean, $(CHISEL_ACC)) $(addsuffix -driver-clean, $(CATAPULTHLS_ACC))
-ACC-app          = $(addsuffix -app, $(STRATUSHLS_ACC)) $(addsuffix -app, $(VIVADOHLS_ACC)) $(addsuffix -app, $(HLS4ML_ACC)) $(addsuffix -app, $(CHISEL_ACC)) $(addsuffix -app, $(CATAPULTHLS_ACC))
-ACC-app-clean    = $(addsuffix -app-clean, $(STRATUSHLS_ACC)) $(addsuffix -app-clean, $(VIVADOHLS_ACC)) $(addsuffix -app-clean, $(HLS4ML_ACC)) $(addsuffix -app-clean, $(CHISEL_ACC)) $(addsuffix -app-clean, $(CATAPULTHLS_ACC))
-ACC-baremetal        = $(addsuffix -baremetal, $(STRATUSHLS_ACC)) $(addsuffix -baremetal, $(VIVADOHLS_ACC)) $(addsuffix -baremetal, $(HLS4ML_ACC)) $(addsuffix -baremetal, $(CHISEL_ACC)) $(addsuffix -baremetal, $(CATAPULTHLS_ACC))
-ACC-baremetal-clean  = $(addsuffix -baremetal-clean, $(STRATUSHLS_ACC)) $(addsuffix -baremetal-clean, $(VIVADOHLS_ACC)) $(addsuffix -baremetal-clean, $(HLS4ML_ACC)) $(addsuffix -baremetal-clean, $(CHISEL_ACC)) $(addsuffix -baremetal-clean, $(CATAPULTHLS_ACC))
+ACC-driver       = $(addsuffix -driver, $(STRATUSHLS_ACC)) $(addsuffix -driver, $(VIVADOHLS_ACC)) $(addsuffix -driver, $(HLS4ML_ACC)) $(addsuffix -driver, $(CHISEL_ACC)) $(addsuffix -driver, $(CATAPULTHLS_ACC)) $(addsuffix -driver, $(RTL_ACC))
+ACC-driver-clean = $(addsuffix -driver-clean, $(STRATUSHLS_ACC)) $(addsuffix -driver-clean, $(VIVADOHLS_ACC)) $(addsuffix -driver-clean, $(HLS4ML_ACC)) $(addsuffix -driver-clean, $(CHISEL_ACC)) $(addsuffix -driver-clean, $(CATAPULTHLS_ACC)) $(addsuffix -driver-clean, $(RTL_ACC))
+ACC-app          = $(addsuffix -app, $(STRATUSHLS_ACC)) $(addsuffix -app, $(VIVADOHLS_ACC)) $(addsuffix -app, $(HLS4ML_ACC)) $(addsuffix -app, $(CHISEL_ACC)) $(addsuffix -app, $(CATAPULTHLS_ACC)) $(addsuffix -app, $(RTL_ACC)) 
+ACC-app-clean    = $(addsuffix -app-clean, $(STRATUSHLS_ACC)) $(addsuffix -app-clean, $(VIVADOHLS_ACC)) $(addsuffix -app-clean, $(HLS4ML_ACC)) $(addsuffix -app-clean, $(CHISEL_ACC)) $(addsuffix -app-clean, $(CATAPULTHLS_ACC)) $(addsuffix -app-clean, $(RTL_ACC))
+ACC-baremetal        = $(addsuffix -baremetal, $(STRATUSHLS_ACC)) $(addsuffix -baremetal, $(VIVADOHLS_ACC)) $(addsuffix -baremetal, $(HLS4ML_ACC)) $(addsuffix -baremetal, $(CHISEL_ACC)) $(addsuffix -baremetal, $(CATAPULTHLS_ACC)) $(addsuffix -baremetal, $(RTL_ACC))
+ACC-baremetal-clean  = $(addsuffix -baremetal-clean, $(STRATUSHLS_ACC)) $(addsuffix -baremetal-clean, $(VIVADOHLS_ACC)) $(addsuffix -baremetal-clean, $(HLS4ML_ACC)) $(addsuffix -baremetal-clean, $(CHISEL_ACC)) $(addsuffix -baremetal-clean, $(CATAPULTHLS_ACC)) $(addsuffix -baremetal-clean, $(RTL_ACC))
 
 print-available-acc:
 	$(QUIET_INFO)echo "Available accelerators generated from Stratus HLS: $(STRATUSHLS_ACC)"
 	$(QUIET_INFO)echo "Available accelerators generated from Vivado HLS: $(VIVADOHLS_ACC)"
 	$(QUIET_INFO)echo "Available accelerators generated from hls4ml: $(HLS4ML_ACC)"
 	$(QUIET_INFO)echo "Available accelerators generated from Chisel3: $(CHISEL_ACC)"
+	$(QUIET_INFO)echo "Available accelerators generated from RTL: $(RTL_ACC)"
 	$(QUIET_INFO)echo "Available third-party accelerators: $(THIRDPARTY_ACC)"
 
 
@@ -352,6 +361,40 @@ catapulthls_acc-clean: $(CATAPULTHLS_ACC-clean)
 catapulthls_acc-distclean: $(CATAPULTHLS_ACC-distclean)
 
 .PHONY: catapulthls_acc catapulthls_acc-clean catapulthls_acc-distclean
+
+### RTL ###
+$(RTL_ACC-wdir):
+	$(QUIET_MKDIR)mkdir -p $(RTL_ACC_PATH)/$(@:-wdir=)/hw/hls-work-$(TECHLIB)
+	@cd $(RTL_ACC_PATH)/$(@:-wdir=)/hw/hls-work-$(TECHLIB); \
+	rm -f Makefile; \
+	ln -s ../hls/Makefile
+
+$(RTL_ACC-hls): %-hls : %-wdir
+	$(QUIET_INFO)echo "Installing available implementations for $(@:-hls=) to $(ESP_ROOT)/tech/$(TECHLIB)/acc/$(@:-hls=)"
+	$(QUIET_MAKE)ACCELERATOR=$(@:-hls=) TECH=$(TECHLIB) ESP_ROOT=$(ESP_ROOT) make -C $(RTL_ACC_PATH)/$(@:-hls=)/hw/hls-work-$(TECHLIB) install
+	@if test -e $(ESP_ROOT)/tech/$(TECHLIB)/acc/installed.log; then \
+		sed -i '/$(@:-hls=)/d' $(ESP_ROOT)/tech/$(TECHLIB)/acc/installed.log; \
+	fi;
+	@echo "$(@:-hls=)" >> $(ESP_ROOT)/tech/$(TECHLIB)/acc/installed.log
+
+$(RTL_ACC-clean): %-clean : %-wdir
+	$(QUIET_CLEAN)ACCELERATOR=$(@:-clean=) TECH=$(TECHLIB) ESP_ROOT=$(ESP_ROOT) make -C $(RTL_ACC_PATH)/$(@:-clean=)/hw/hls-work-$(TECHLIB) clean
+
+$(RTL_ACC-distclean): %-distclean : %-wdir
+	$(QUIET_CLEAN)ACCELERATOR=$(@:-distclean=) TECH=$(TECHLIB) ESP_ROOT=$(ESP_ROOT) make -C $(RTL_ACC_PATH)/$(@:-distclean=)/hw/hls-work-$(TECHLIB) distclean
+	@if test -e $(ESP_ROOT)/tech/$(TECHLIB)/acc/installed.log; then \
+		sed -i '/$(@:-distclean=)/d' $(ESP_ROOT)/tech/$(TECHLIB)/acc/installed.log; \
+	fi;
+
+.PHONY: print-available-acc $(RTL_ACC-wdir) $(RTL_ACC-hls) $(RTL_ACC-clean) $(RTL_ACC-distclean)
+
+rtl_acc: $(RTL_ACC-hls)
+
+rtl_acc-clean: $(RTL_ACC-clean)
+
+rtl_acc-distclean: $(RTL_ACC-distclean)
+
+.PHONY: rtl_acc rtl_acc-clean rtl_acc-distclean
 
 ### Common ###
 $(ESP_ROOT)/tech/$(TECHLIB)/acc/installed.log:


### PR DESCRIPTION
Add support to ESP for creating and integrating an accelerator designed in Verilog, SystemVerilog or VHDL.

This RTL accelerator design flow is a preliminary version. Like other accelerator design flow in ESP, it includes the automated integration of the accelerator and the generation of Linux device driver and skeletons of the bare-metal and Linux test applications. However, it generates an empty top module of the accelerator, and the job of implementing the accelerator is left to the designer.

Here is the [tutorial guide](https://www.esp.cs.columbia.edu/docs/rtl_acc) for this design flow.