### PR TITLE
Fixes to SLM+DDR tile 

### DIFF
--- a/rtl/sockets/csr/esp_csr_pkg.vhd
+++ b/rtl/sockets/csr/esp_csr_pkg.vhd
@@ -63,6 +63,8 @@ package esp_csr_pkg is
 
   constant ESP_CSR_SRST_ADDR : integer range 0 to 31 := 31;  -- reserved address
 
+  constant DCO_CFG_LPDDR_CTRL_BITS : integer range 0 to 31 := 12;
+
   component esp_tile_csr
     generic (
       pindex : integer range 0 to NAPBSLV - 1;

--- a/rtl/sockets/csr/esp_csr_pkg.vhd
+++ b/rtl/sockets/csr/esp_csr_pkg.vhd
@@ -10,7 +10,7 @@ use work.monitor_pkg.all;
 
 package esp_csr_pkg is
 
-  constant ESP_CSR_8_LSB : integer := 71 + CFG_NCPU_TILE * 2 * 3;
+  constant ESP_CSR_8_LSB : integer := 79 + CFG_NCPU_TILE * 2 * 3;
   constant ESP_CSR_WIDTH : integer := 98 + ESP_CSR_8_LSB;
 
   constant ESP_CSR_VALID_ADDR : integer range 0 to 31 := 0;
@@ -27,23 +27,23 @@ package esp_csr_pkg is
 
   constant ESP_CSR_DCO_CFG_ADDR : integer range 0 to 31 := 3;
   constant ESP_CSR_DCO_CFG_LSB : integer range 0 to ESP_CSR_WIDTH - 1 := 12;
-  constant ESP_CSR_DCO_CFG_MSB : integer range 0 to ESP_CSR_WIDTH - 1 := 34;
+  constant ESP_CSR_DCO_CFG_MSB : integer range 0 to ESP_CSR_WIDTH - 1 := 42;
 
   constant ESP_CSR_DCO_NOC_CFG_ADDR : integer range 0 to 31 := 4;
-  constant ESP_CSR_DCO_NOC_CFG_LSB : integer range 0 to ESP_CSR_WIDTH - 1 := 35;
-  constant ESP_CSR_DCO_NOC_CFG_MSB : integer range 0 to ESP_CSR_WIDTH - 1 := 53;
+  constant ESP_CSR_DCO_NOC_CFG_LSB : integer range 0 to ESP_CSR_WIDTH - 1 := 43;
+  constant ESP_CSR_DCO_NOC_CFG_MSB : integer range 0 to ESP_CSR_WIDTH - 1 := 61;
 
   constant ESP_CSR_MDC_SCALER_CFG_ADDR : integer range 0 to 31 := 5;
-  constant ESP_CSR_MDC_SCALER_CFG_LSB : integer range 0 to ESP_CSR_WIDTH - 1 := 54;
-  constant ESP_CSR_MDC_SCALER_CFG_MSB : integer range 0 to ESP_CSR_WIDTH - 1 := 64;
+  constant ESP_CSR_MDC_SCALER_CFG_LSB : integer range 0 to ESP_CSR_WIDTH - 1 := 62;
+  constant ESP_CSR_MDC_SCALER_CFG_MSB : integer range 0 to ESP_CSR_WIDTH - 1 := 72;
 
   constant ESP_CSR_ARIANE_HARTID_ADDR : integer range 0 to 31 := 6;
-  constant ESP_CSR_ARIANE_HARTID_LSB : integer range 0 to ESP_CSR_WIDTH - 1 := 65;
-  constant ESP_CSR_ARIANE_HARTID_MSB : integer range 0 to ESP_CSR_WIDTH - 1 := 69;
+  constant ESP_CSR_ARIANE_HARTID_LSB : integer range 0 to ESP_CSR_WIDTH - 1 := 73;
+  constant ESP_CSR_ARIANE_HARTID_MSB : integer range 0 to ESP_CSR_WIDTH - 1 := 77;
 
   constant ESP_CSR_CPU_LOC_OVR_ADDR : integer range 0 to 31 := 7;
-  constant ESP_CSR_CPU_LOC_OVR_LSB : integer range 0 to ESP_CSR_WIDTH - 1 := 70;
-  constant ESP_CSR_CPU_LOC_OVR_MSB : integer range 0 to ESP_CSR_WIDTH - 1 := 70 + CFG_NCPU_TILE * 2 * 3;
+  constant ESP_CSR_CPU_LOC_OVR_LSB : integer range 0 to ESP_CSR_WIDTH - 1 := 78;
+  constant ESP_CSR_CPU_LOC_OVR_MSB : integer range 0 to ESP_CSR_WIDTH - 1 := 78 + CFG_NCPU_TILE * 2 * 3;
 
   constant ESP_CSR_DDR_CFG0_ADDR : integer range 0 to 31 := 8;
   constant ESP_CSR_DDR_CFG0_LSB : integer range 0 to ESP_CSR_WIDTH - 1 := ESP_CSR_8_LSB;
@@ -66,7 +66,7 @@ package esp_csr_pkg is
   component esp_tile_csr
     generic (
       pindex : integer range 0 to NAPBSLV - 1;
-      dco_rst_cfg : std_logic_vector(22 downto 0) := (others => '0'));
+      dco_rst_cfg : std_logic_vector(30 downto 0) := (others => '0'));
     port (
       clk         : in std_logic;
       rstn        : in std_logic;

--- a/rtl/sockets/csr/esp_tile_csr.vhd
+++ b/rtl/sockets/csr/esp_tile_csr.vhd
@@ -20,7 +20,7 @@ entity esp_tile_csr is
 
   generic (
     pindex      : integer range 0 to NAPBSLV -1 := 0;
-    dco_rst_cfg : std_logic_vector(22 downto 0) := (others => '0'));
+    dco_rst_cfg : std_logic_vector(30 downto 0) := (others => '0'));
   port (
     clk         : in std_logic;
     rstn        : in std_logic;
@@ -122,8 +122,8 @@ architecture rtl of esp_tile_csr is
        "00"     &  "100"   &  "000000" & "100101" & "0"     & "1";
     -- FREQ_SEL    DIV_SEL    FC_SEL      CC_SEL    CLK_SEL   EN
 
-    constant DEFAULT_DCO_CFG : std_logic_vector(22 downto 0) :=
-       "0000"          & "00"     &  "100"   &  "000000" & "100101" & "0"     & "1";
+    constant DEFAULT_DCO_CFG : std_logic_vector(30 downto 0) :=
+       "000000000000"          & "00"     &  "100"   &  "000000" & "100101" & "0"     & "1";
     --  reserved LPDDR   FREQ_SEL    DIV_SEL    FC_SEL      CC_SEL    CLK_SEL   EN
 
     constant DEFAULT_PAD_CFG : std_logic_vector(2 downto 0) :=
@@ -137,7 +137,7 @@ architecture rtl of esp_tile_csr is
     function dco_reset_config_ovr
       return std_logic_vector is
     begin
-      if dco_rst_cfg = ("000" & X"00000") then
+      if dco_rst_cfg = ("000" & X"0000000") then
         -- Use default
         return DEFAULT_DCO_CFG;
       else
@@ -146,7 +146,7 @@ architecture rtl of esp_tile_csr is
       end if;
     end function;
 
-    constant RESET_DCO_CFG : std_logic_vector(22 downto 0) := dco_reset_config_ovr;
+    constant RESET_DCO_CFG : std_logic_vector(30 downto 0) := dco_reset_config_ovr;
 
     constant DEFAULT_CONFIG : std_logic_vector(ESP_CSR_WIDTH - 1 downto 0) :=
         DEFAULT_ACC_COH & DEFAULT_DDR_CFG2 & DEFAULT_DDR_CFG1 & DEFAULT_DDR_CFG0 & DEFAULT_CPU_LOC_OVR & DEFAULT_ARIANE_HARTID &

--- a/rtl/tiles/asic/asic_tile_slm_ddr.vhd
+++ b/rtl/tiles/asic/asic_tile_slm_ddr.vhd
@@ -211,7 +211,7 @@ architecture rtl of asic_tile_slm_ddr is
   constant ext_clk_sel_default : std_ulogic := '0';
 
   constant DEFAULT_DCO_LPDDR_CFG : std_logic_vector(30 downto 0) :=
-    "00000000" & "0100"      &   "00"   &   "100"  & "000000" & "110010" &   "0"   & "1";
+    "00000001" & "1000"      &   "00"   &   "100"  & "000000" & "110010" &   "0"   & "1";
   -- DCO_CLK_DEL  UI_CLK_DEL   FREQ_SEL    DIV_SEL    FC_SEL     CC_SEL    CLK_SEL    EN
 
   -- Tile clock and reset (only for I/O tile)
@@ -649,7 +649,7 @@ begin
      HAS_SYNC => 1 )
    port map (
      clk                => sys_clk,
-     clk_tile           => dco_clk,
+     clk_tile           => dco_clk_div2_90,
      rst                => noc_rstn,
      rst_tile           => dco_rstn,
      CONST_local_x      => this_local_x,

--- a/rtl/tiles/asic/asic_tile_slm_ddr.vhd
+++ b/rtl/tiles/asic/asic_tile_slm_ddr.vhd
@@ -210,9 +210,9 @@ architecture rtl of asic_tile_slm_ddr is
 
   constant ext_clk_sel_default : std_ulogic := '0';
 
-  constant DEFAULT_DCO_LPDDR_CFG : std_logic_vector(22 downto 0) :=
-    "0100"      &   "00"   &   "100"  & "000000" & "110010" &   "0"   & "1";
-  -- UI_CLK_DEL   FREQ_SEL    DIV_SEL    FC_SEL     CC_SEL    CLK_SEL    EN
+  constant DEFAULT_DCO_LPDDR_CFG : std_logic_vector(30 downto 0) :=
+    "00000000" & "0100"      &   "00"   &   "100"  & "000000" & "110010" &   "0"   & "1";
+  -- DCO_CLK_DEL  UI_CLK_DEL   FREQ_SEL    DIV_SEL    FC_SEL     CC_SEL    CLK_SEL    EN
 
   -- Tile clock and reset (only for I/O tile)
   signal raw_rstn        : std_ulogic;

--- a/rtl/tiles/asic/asic_tile_slm_ddr.vhd
+++ b/rtl/tiles/asic/asic_tile_slm_ddr.vhd
@@ -524,7 +524,7 @@ begin
       test_if_en => 1)
     port map (
       rst                 => test_rstn,
-      refclk              => dco_clk,
+      refclk              => dco_clk_div2_90,
       tile_rst            => dco_rstn,
       tdi                 => tdi,
       tdo                 => tdo,

--- a/rtl/tiles/tile_cpu.vhd
+++ b/rtl/tiles/tile_cpu.vhd
@@ -362,10 +362,10 @@ begin
         clk_div  => pllclk,
         lock     => dco_clk_lock);
 
-    dco_freq_sel <= tile_config(ESP_CSR_DCO_CFG_MSB - 4  - 0  downto ESP_CSR_DCO_CFG_MSB - 4  - 0  - 1);
-    dco_div_sel  <= tile_config(ESP_CSR_DCO_CFG_MSB - 4  - 2  downto ESP_CSR_DCO_CFG_MSB - 4  - 2  - 2);
-    dco_fc_sel   <= tile_config(ESP_CSR_DCO_CFG_MSB - 4  - 5  downto ESP_CSR_DCO_CFG_MSB - 4  - 5  - 5);
-    dco_cc_sel   <= tile_config(ESP_CSR_DCO_CFG_MSB - 4  - 11 downto ESP_CSR_DCO_CFG_MSB - 4  - 11 - 5);
+    dco_freq_sel <= tile_config(ESP_CSR_DCO_CFG_MSB - DCO_CFG_LPDDR_CTRL_BITS  - 0  downto ESP_CSR_DCO_CFG_MSB - DCO_CFG_LPDDR_CTRL_BITS  - 0  - 1);
+    dco_div_sel  <= tile_config(ESP_CSR_DCO_CFG_MSB - DCO_CFG_LPDDR_CTRL_BITS  - 2  downto ESP_CSR_DCO_CFG_MSB - DCO_CFG_LPDDR_CTRL_BITS  - 2  - 2);
+    dco_fc_sel   <= tile_config(ESP_CSR_DCO_CFG_MSB - DCO_CFG_LPDDR_CTRL_BITS  - 5  downto ESP_CSR_DCO_CFG_MSB - DCO_CFG_LPDDR_CTRL_BITS  - 5  - 5);
+    dco_cc_sel   <= tile_config(ESP_CSR_DCO_CFG_MSB - DCO_CFG_LPDDR_CTRL_BITS  - 11 downto ESP_CSR_DCO_CFG_MSB - DCO_CFG_LPDDR_CTRL_BITS  - 11 - 5);
     dco_clk_sel  <= tile_config(ESP_CSR_DCO_CFG_LSB  + 1);
     dco_en       <= raw_rstn and tile_config(ESP_CSR_DCO_CFG_LSB);
 

--- a/rtl/tiles/tile_empty.vhd
+++ b/rtl/tiles/tile_empty.vhd
@@ -188,10 +188,10 @@ begin
         clk_div  => pllclk,
         lock     => dco_clk_lock);
 
-    dco_freq_sel <= tile_config(ESP_CSR_DCO_CFG_MSB - 4 - 0  downto ESP_CSR_DCO_CFG_MSB - 4 - 0  - 1);
-    dco_div_sel  <= tile_config(ESP_CSR_DCO_CFG_MSB - 4 - 2  downto ESP_CSR_DCO_CFG_MSB - 4 - 2  - 2);
-    dco_fc_sel   <= tile_config(ESP_CSR_DCO_CFG_MSB - 4 - 5  downto ESP_CSR_DCO_CFG_MSB - 4 - 5  - 5);
-    dco_cc_sel   <= tile_config(ESP_CSR_DCO_CFG_MSB - 4 - 11 downto ESP_CSR_DCO_CFG_MSB - 4 - 11 - 5);
+    dco_freq_sel <= tile_config(ESP_CSR_DCO_CFG_MSB - DCO_CFG_LPDDR_CTRL_BITS - 0  downto ESP_CSR_DCO_CFG_MSB - DCO_CFG_LPDDR_CTRL_BITS - 0  - 1);
+    dco_div_sel  <= tile_config(ESP_CSR_DCO_CFG_MSB - DCO_CFG_LPDDR_CTRL_BITS - 2  downto ESP_CSR_DCO_CFG_MSB - DCO_CFG_LPDDR_CTRL_BITS - 2  - 2);
+    dco_fc_sel   <= tile_config(ESP_CSR_DCO_CFG_MSB - DCO_CFG_LPDDR_CTRL_BITS - 5  downto ESP_CSR_DCO_CFG_MSB - DCO_CFG_LPDDR_CTRL_BITS - 5  - 5);
+    dco_cc_sel   <= tile_config(ESP_CSR_DCO_CFG_MSB - DCO_CFG_LPDDR_CTRL_BITS - 11 downto ESP_CSR_DCO_CFG_MSB - DCO_CFG_LPDDR_CTRL_BITS - 11 - 5);
     dco_clk_sel  <= tile_config(ESP_CSR_DCO_CFG_LSB + 1);
     dco_en       <= raw_rstn and tile_config(ESP_CSR_DCO_CFG_LSB);
 

--- a/rtl/tiles/tile_io.vhd
+++ b/rtl/tiles/tile_io.vhd
@@ -438,10 +438,10 @@ begin
         clk_div  => pllclk,
         lock     => dco_clk_lock);
 
-    dco_freq_sel <= tile_config(ESP_CSR_DCO_CFG_MSB - 4 - 0  downto ESP_CSR_DCO_CFG_MSB - 4 - 0  - 1);
-    dco_div_sel  <= tile_config(ESP_CSR_DCO_CFG_MSB - 4 - 2  downto ESP_CSR_DCO_CFG_MSB - 4 - 2  - 2);
-    dco_fc_sel   <= tile_config(ESP_CSR_DCO_CFG_MSB - 4 - 5  downto ESP_CSR_DCO_CFG_MSB - 4 - 5  - 5);
-    dco_cc_sel   <= tile_config(ESP_CSR_DCO_CFG_MSB - 4 - 11 downto ESP_CSR_DCO_CFG_MSB - 4 - 11 - 5);
+    dco_freq_sel <= tile_config(ESP_CSR_DCO_CFG_MSB - DCO_CFG_LPDDR_CTRL_BITS - 0  downto ESP_CSR_DCO_CFG_MSB - DCO_CFG_LPDDR_CTRL_BITS - 0  - 1);
+    dco_div_sel  <= tile_config(ESP_CSR_DCO_CFG_MSB - DCO_CFG_LPDDR_CTRL_BITS - 2  downto ESP_CSR_DCO_CFG_MSB - DCO_CFG_LPDDR_CTRL_BITS - 2  - 2);
+    dco_fc_sel   <= tile_config(ESP_CSR_DCO_CFG_MSB - DCO_CFG_LPDDR_CTRL_BITS - 5  downto ESP_CSR_DCO_CFG_MSB - DCO_CFG_LPDDR_CTRL_BITS - 5  - 5);
+    dco_cc_sel   <= tile_config(ESP_CSR_DCO_CFG_MSB - DCO_CFG_LPDDR_CTRL_BITS - 11 downto ESP_CSR_DCO_CFG_MSB - DCO_CFG_LPDDR_CTRL_BITS - 11 - 5);
     dco_clk_sel  <= tile_config(ESP_CSR_DCO_CFG_LSB + 1);
     dco_en       <= raw_rstn and tile_config(ESP_CSR_DCO_CFG_LSB);
 

--- a/rtl/tiles/tile_mem.vhd
+++ b/rtl/tiles/tile_mem.vhd
@@ -337,10 +337,10 @@ begin
 
 
   -- DCO runtime reconfiguration
-  dco_freq_sel <= tile_config(ESP_CSR_DCO_CFG_MSB - 4 - 0  downto ESP_CSR_DCO_CFG_MSB - 4 - 0  - 1);
-  dco_div_sel  <= tile_config(ESP_CSR_DCO_CFG_MSB - 4 - 2  downto ESP_CSR_DCO_CFG_MSB - 4 - 2  - 2);
-  dco_fc_sel   <= tile_config(ESP_CSR_DCO_CFG_MSB - 4 - 5  downto ESP_CSR_DCO_CFG_MSB - 4 - 5  - 5);
-  dco_cc_sel   <= tile_config(ESP_CSR_DCO_CFG_MSB - 4 - 11 downto ESP_CSR_DCO_CFG_MSB - 4 - 11 - 5);
+  dco_freq_sel <= tile_config(ESP_CSR_DCO_CFG_MSB - DCO_CFG_LPDDR_CTRL_BITS - 0  downto ESP_CSR_DCO_CFG_MSB - DCO_CFG_LPDDR_CTRL_BITS - 0  - 1);
+  dco_div_sel  <= tile_config(ESP_CSR_DCO_CFG_MSB - DCO_CFG_LPDDR_CTRL_BITS - 2  downto ESP_CSR_DCO_CFG_MSB - DCO_CFG_LPDDR_CTRL_BITS - 2  - 2);
+  dco_fc_sel   <= tile_config(ESP_CSR_DCO_CFG_MSB - DCO_CFG_LPDDR_CTRL_BITS - 5  downto ESP_CSR_DCO_CFG_MSB - DCO_CFG_LPDDR_CTRL_BITS - 5  - 5);
+  dco_cc_sel   <= tile_config(ESP_CSR_DCO_CFG_MSB - DCO_CFG_LPDDR_CTRL_BITS - 11 downto ESP_CSR_DCO_CFG_MSB - DCO_CFG_LPDDR_CTRL_BITS - 11 - 5);
   dco_clk_sel  <= tile_config(ESP_CSR_DCO_CFG_LSB + 1);
   dco_en       <= raw_rstn and tile_config(ESP_CSR_DCO_CFG_LSB);
 

--- a/rtl/tiles/tile_mem.vhd
+++ b/rtl/tiles/tile_mem.vhd
@@ -38,7 +38,7 @@ entity tile_mem is
     SIMULATION   : boolean := false;
     this_has_dco : integer range 0 to 1 := 0;
     this_has_ddr : integer range 0 to 1 := 1;
-    dco_rst_cfg  : std_logic_vector(22 downto 0) := (others => '0'));
+    dco_rst_cfg  : std_logic_vector(30 downto 0) := (others => '0'));
   port (
     raw_rstn           : in  std_ulogic;
     tile_rst           : in  std_ulogic;

--- a/rtl/tiles/tile_slm.vhd
+++ b/rtl/tiles/tile_slm.vhd
@@ -288,17 +288,25 @@ begin
           sel      => dco_clk_delay_sel(3 downto 0),
           data_out => dco_clk_div2_90_int);
 
-      DELAY_CELL_GF12_C14_2: DELAY_CELL_GF12_C14
-        port map (
-          data_in  => dco_clk_div2_int,
-          sel      => dco_clk_delay_sel(7 downto 4),
-          data_out => dco_clk_div2_int_delay);
+      delay_ddr_gen : if this_has_ddr /= 0 generate
+        DELAY_CELL_GF12_C14_2: DELAY_CELL_GF12_C14
+          port map (
+            data_in  => dco_clk_div2_int,
+            sel      => dco_clk_delay_sel(7 downto 4),
+            data_out => dco_clk_div2_int_delay);
 
-      DELAY_CELL_GF12_C14_3: DELAY_CELL_GF12_C14
-        port map (
-          data_in  => dco_clk_int,
-          sel      => dco_clk_delay_sel(11 downto 8),
-          data_out => dco_clk_int_delay);
+        DELAY_CELL_GF12_C14_3: DELAY_CELL_GF12_C14
+          port map (
+            data_in  => dco_clk_int,
+            sel      => dco_clk_delay_sel(11 downto 8),
+            data_out => dco_clk_int_delay);
+      end generate delay_ddr_gen;
+
+      no_delay_ddr_gen : if this_has_ddr = 0 generate
+        dco_clk_div2_int_delay <= dco_clk_div2_int;
+        dco_clk_int_delay <= dco_clk_int;
+      end generate no_delay_ddr_gen;
+      
     end generate clk_delay_gf12_gen;
 
     noc_clk_delay_gen: if CFG_FABTECH /= gf12 generate

--- a/rtl/tiles/tile_slm.vhd
+++ b/rtl/tiles/tile_slm.vhd
@@ -38,7 +38,7 @@ entity tile_slm is
     SIMULATION   : boolean := false;
     this_has_dco : integer range 0 to 1 := 0;
     this_has_ddr : integer range 0 to 1 := 0;
-    dco_rst_cfg  : std_logic_vector(22 downto 0) := (others => '0'));
+    dco_rst_cfg  : std_logic_vector(30 downto 0) := (others => '0'));
   port (
     raw_rstn           : in  std_ulogic;
     tile_rst           : in  std_ulogic;
@@ -124,11 +124,13 @@ architecture rtl of tile_slm is
   signal dco_freq_sel : std_logic_vector(1 downto 0);
   signal dco_clk_lock : std_ulogic;
   signal dco_clk_int  : std_ulogic;
+  signal dco_clk_int_delay      : std_ulogic;
+  signal dco_clk_div2_int_delay : std_ulogic;
 
   -- Delay line for DDR ui_clk delay
   signal dco_clk_div2_int    : std_logic;
   signal dco_clk_div2_90_int : std_logic;
-  signal dco_clk_delay_sel   : std_logic_vector(3 downto 0);
+  signal dco_clk_delay_sel   : std_logic_vector(11 downto 0);
   component DELAY_CELL_GF12_C14 is
     port (
       data_in : in std_logic;
@@ -283,8 +285,20 @@ begin
       DELAY_CELL_GF12_C14_1: DELAY_CELL_GF12_C14
         port map (
           data_in  => dco_clk_div2_int,
-          sel      => dco_clk_delay_sel,
+          sel      => dco_clk_delay_sel(3 downto 0),
           data_out => dco_clk_div2_90_int);
+
+      DELAY_CELL_GF12_C14_2: DELAY_CELL_GF12_C14
+        port map (
+          data_in  => dco_clk_div2_int,
+          sel      => dco_clk_delay_sel(7 downto 4),
+          data_out => dco_clk_div2_int_delay);
+
+      DELAY_CELL_GF12_C14_3: DELAY_CELL_GF12_C14
+        port map (
+          data_in  => dco_clk_int,
+          sel      => dco_clk_delay_sel(11 downto 8),
+          data_out => dco_clk_int_delay);
     end generate clk_delay_gf12_gen;
 
     noc_clk_delay_gen: if CFG_FABTECH /= gf12 generate
@@ -309,8 +323,8 @@ begin
     dco_clk_div2_90_int <= '0';
   end generate no_dco_gen;
 
-  dco_clk         <= dco_clk_int;
-  dco_clk_div2    <= dco_clk_div2_int;
+  dco_clk         <= dco_clk_int_delay;
+  dco_clk_div2    <= dco_clk_div2_int_delay;
   dco_clk_div2_90 <= dco_clk_div2_90_int;
 
   -- DDR Controller configuration
@@ -318,7 +332,7 @@ begin
   ddr_cfg1 <= tile_config(ESP_CSR_DDR_CFG1_MSB downto ESP_CSR_DDR_CFG1_LSB);
   ddr_cfg2 <= tile_config(ESP_CSR_DDR_CFG2_MSB downto ESP_CSR_DDR_CFG2_LSB);
 
-  dco_clk_delay_sel <= tile_config(ESP_CSR_DCO_CFG_MSB downto ESP_CSR_DCO_CFG_MSB - 3);
+  dco_clk_delay_sel <= tile_config(ESP_CSR_DCO_CFG_MSB downto ESP_CSR_DCO_CFG_MSB - 11);
 
   -----------------------------------------------------------------------------
   -- Tile parameters

--- a/rtl/tiles/tile_slm.vhd
+++ b/rtl/tiles/tile_slm.vhd
@@ -306,7 +306,7 @@ begin
         dco_clk_div2_int_delay <= dco_clk_div2_int;
         dco_clk_int_delay <= dco_clk_int;
       end generate no_delay_ddr_gen;
-      
+
     end generate clk_delay_gf12_gen;
 
     noc_clk_delay_gen: if CFG_FABTECH /= gf12 generate
@@ -316,10 +316,10 @@ begin
   end generate dco_gen;
 
   -- DCO runtime reconfiguration
-  dco_freq_sel <= tile_config(ESP_CSR_DCO_CFG_MSB - 4 - 0  downto ESP_CSR_DCO_CFG_MSB - 4 - 0  - 1);
-  dco_div_sel  <= tile_config(ESP_CSR_DCO_CFG_MSB - 4 - 2  downto ESP_CSR_DCO_CFG_MSB - 4 - 2  - 2);
-  dco_fc_sel   <= tile_config(ESP_CSR_DCO_CFG_MSB - 4 - 5  downto ESP_CSR_DCO_CFG_MSB - 4 - 5  - 5);
-  dco_cc_sel   <= tile_config(ESP_CSR_DCO_CFG_MSB - 4 - 11 downto ESP_CSR_DCO_CFG_MSB - 4 - 11 - 5);
+  dco_freq_sel <= tile_config(ESP_CSR_DCO_CFG_MSB - DCO_CFG_LPDDR_CTRL_BITS - 0  downto ESP_CSR_DCO_CFG_MSB - DCO_CFG_LPDDR_CTRL_BITS - 0  - 1);
+  dco_div_sel  <= tile_config(ESP_CSR_DCO_CFG_MSB - DCO_CFG_LPDDR_CTRL_BITS - 2  downto ESP_CSR_DCO_CFG_MSB - DCO_CFG_LPDDR_CTRL_BITS - 2  - 2);
+  dco_fc_sel   <= tile_config(ESP_CSR_DCO_CFG_MSB - DCO_CFG_LPDDR_CTRL_BITS - 5  downto ESP_CSR_DCO_CFG_MSB - DCO_CFG_LPDDR_CTRL_BITS - 5  - 5);
+  dco_cc_sel   <= tile_config(ESP_CSR_DCO_CFG_MSB - DCO_CFG_LPDDR_CTRL_BITS - 11 downto ESP_CSR_DCO_CFG_MSB - DCO_CFG_LPDDR_CTRL_BITS - 11 - 5);
   dco_clk_sel  <= tile_config(ESP_CSR_DCO_CFG_LSB + 1);
   dco_en       <= raw_rstn and tile_config(ESP_CSR_DCO_CFG_LSB);
 

--- a/rtl/tiles/tiles_pkg.vhd
+++ b/rtl/tiles/tiles_pkg.vhd
@@ -282,7 +282,7 @@ package tiles_pkg is
       SIMULATION   : boolean := false;
       this_has_dco : integer range 0 to 1 := 0;
       this_has_ddr : integer range 0 to 1 := 1;
-      dco_rst_cfg  : std_logic_vector(22 downto 0) := (others => '0'));
+      dco_rst_cfg  : std_logic_vector(30 downto 0) := (others => '0'));
     port (
       raw_rstn           : in  std_ulogic;
       tile_rst           : in  std_ulogic;
@@ -432,7 +432,7 @@ package tiles_pkg is
       SIMULATION   : boolean := false;
       this_has_dco : integer range 0 to 1 := 0;
       this_has_ddr : integer range 0 to 1 := 0;
-      dco_rst_cfg  : std_logic_vector(22 downto 0) := (others => '0'));
+      dco_rst_cfg  : std_logic_vector(30 downto 0) := (others => '0'));
     port (
       raw_rstn           : in  std_ulogic;
       tile_rst           : in  std_ulogic;


### PR DESCRIPTION
-use correct clocks in asic_tile_slm_ddr
-add configurable delay cells on dco outputs in tile_slm
-fix ahb2bsg_dmc to support accelerator execution to slm_ddr tile
-modify delay cell configuration from CSRs