### PR TITLE
correct linker argument order in baremetal makefile

### DIFF
--- a/soft/common/drivers/baremetal/common_bare.mk
+++ b/soft/common/drivers/baremetal/common_bare.mk
@@ -83,7 +83,7 @@ $(BUILD_PATH)/%.exe: %.c $(OBJS) $(SRCS_PROBE) $(HEADERS)
 	CPU_ARCH=$(CPU_ARCH) DESIGN_PATH=$(DESIGN_PATH) BUILD_PATH=$(BUILD_PATH)/../../monitors MODE=BAREC \
 			 $(MAKE) -B -C $(DRIVERS)/../common/monitors
 	CPU_ARCH=$(CPU_ARCH) DESIGN_PATH=$(DESIGN_PATH) BUILD_PATH=$(BUILD_PATH)/../../utils/baremetal $(MAKE) -C $(DRIVERS)/utils
-	$(CC) $(CFLAGS) -o $@ $< $(LDFLAGS_RISCV) $(LDFLAGS) $(OBJS)
+	$(CC) $(CFLAGS) -o $@ $< $(LDFLAGS_RISCV) $(OBJS) $(LDFLAGS)
 
 $(BUILD_PATH)/%.bin: $(BUILD_PATH)/%.exe
 	$(CROSS_COMPILE)objcopy -O binary $(OBJCPFLAGS) $< $@


### PR DESCRIPTION
note: converted to draft as it was added to another PR: https://github.com/sld-columbia/esp/pull/273

Fix undefined symbol errors by placing object files before libraries in the linker command.
The GNU linker resolves symbols left-to-right, so libraries must come after the objects that reference them.
