### PR TITLE
Fix: Ariane baremetal libm toolchain/runtime support

### DIFF
--- a/soft/ariane/common/syscalls.c
+++ b/soft/ariane/common/syscalls.c
@@ -17,6 +17,9 @@ extern volatile uint64_t fromhost;
 #define NUM_COUNTERS 2
 static uintptr_t counters[NUM_COUNTERS];
 static char *counter_names[NUM_COUNTERS];
+static __thread int errno_value;
+
+int *__errno(void) { return &errno_value; }
 
 void setStats(int enable)
 {

--- a/utils/toolchain/build_riscv_toolchain.sh
+++ b/utils/toolchain/build_riscv_toolchain.sh
@@ -17,6 +17,7 @@ BUILDROOT_SHA_PYTHON=fbff7d7289cc95db991184f890f4ca1fcf8a101e
 
 # A patch for buildroot RISCV64 with numpy enabled
 BUILDROOT_PATCH=${ESP_ROOT}/utils/toolchain/python-patches/python-numpy.patch
+RISCV_NEWLIB_CMODEL=medany
 
 DEFAULT_TARGET_DIR="/home/${USER}/riscv"
 TMP=${ESP_ROOT}/_riscv_build
@@ -125,6 +126,7 @@ cd $TMP
 # Bare-metal compiler
 src=riscv-gnu-toolchain
 echo "*** Installing baremetal newlib tool chain... ***"
+echo "*** Configuring baremetal newlib with --with-cmodel=${RISCV_NEWLIB_CMODEL} for Ariane/ESP baremetal apps ***"
 if [ $(noyes "Skip ${src}") == "n" ]; then
     if test -e $src; then
 	cd $src
@@ -136,7 +138,7 @@ if [ $(noyes "Skip ${src}") == "n" ]; then
 
     git reset --hard ${RISCV_GNU_TOOLCHAIN_SHA}
     git submodule update --init --recursive
-    ./configure --prefix=${TARGET_DIR} --disable-gdb
+    ./configure --prefix=${TARGET_DIR} --disable-gdb --with-cmodel=${RISCV_NEWLIB_CMODEL}
     cmd="make -j ${NTHREADS}"
     runsudo ${TARGET_DIR} "$cmd"
 


### PR DESCRIPTION
## Summary

This PR fixes Ariane baremetal support for Newlib `libm`.

Ariane baremetal applications in ESP are compiled with `-mcmodel=medany` and linked in a high-address memory layout, but the baremetal toolchain was still building Newlib/libm with the default code model. That mismatch caused link failures when Ariane apps pulled in functions such as `expf` and `tanhf`. After addressing that, the remaining issue was that Newlib `libm` expected a baremetal `__errno()` implementation, which Ariane was not providing.

## Changes

- Updated the baremetal RISC-V toolchain build to configure Newlib with `--with-cmodel=medany`
- Added a minimal `__errno()` implementation to the Ariane baremetal runtime

These changes allow Ariane baremetal applications to link against the real system `libm` instead of requiring application-specific math workarounds.

This fixes the two issues observed when enabling real `libm` support:

- `relocation truncated to fit: R_RISCV_HI20 against '.LC0'`
- `undefined reference to '__errno'`

## Scope

This PR is intentionally limited to the common Ariane baremetal toolchain/runtime flow:

- `utils/toolchain/build_riscv_toolchain.sh`
- `soft/ariane/common/syscalls.c`

## Notes

This keeps the fix in the infrastructure layer rather than pushing special-case handling into individual baremetal applications.
