### PR TITLE
Fix: LLC AXI write-request resume state

### DIFF
--- a/rtl/caches/llc_wrapper_axi.vhd
+++ b/rtl/caches/llc_wrapper_axi.vhd
@@ -944,7 +944,8 @@ begin  -- architecture rtl
           aw_valid <= '1';
 
           if (aw_ready = '1') then
-            reg.state := load_line;
+            -- A stalled write-address handshake must resume the write-data path.
+            reg.state := store_line;
           end if;
 
         -- LOAD LINE


### PR DESCRIPTION
## Summary

This fixes a state transition bug in `rtl/caches/llc_wrapper_axi.vhd`.

When an LLC write request stalled on `AW_READY`, the AXI bridge moved from
`write_request` to `load_line` once the address handshake completed. That is the
read-data path. The bridge should instead resume the write-data path by moving
to `store_line`.

## Why this matters

Under memory-interface backpressure, a stalled write-address handshake could push the LLC AXI bridge into the wrong state machine path. That can turn normal write contention into severe stalls and incorrect progress on the memory side.

## Change

- In `write_request`, change the post-`AW_READY` transition from:
  - `load_line`
- To:
  - `store_line`