### PR TITLE
Fix: Ariane Wrapper and noc2ahbmst fixes 

### DIFF
--- a/rtl/cores/ariane/ariane_wrap.sv
+++ b/rtl/cores/ariane/ariane_wrap.sv
@@ -313,6 +313,9 @@ module ariane_wrap #(
     output logic                flush_done
 );
 
+    // Avoid zero-width downstream atomic bookkeeping in some elaborators.
+    localparam int AXI_ATOMICS_MAX_WRITE_TXNS = 2;
+
     // Base addresses for Ariane
     localparam ariane_pkg::ariane_cfg_t ArianeSocCfg = '{
         RASDepth: 2,
@@ -351,6 +354,13 @@ module ariane_wrap #(
         SLMDDR = 4,
         DRAM   = 5
     } axi_slaves_t;
+
+    logic [0:0][NSLV-1:0] axi_xbar_valid_rule;
+
+    always_comb begin
+        axi_xbar_valid_rule[0]         = {NSLV{1'b1}};
+        axi_xbar_valid_rule[0][SLMDDR] = |SLMDDRLength[AXI_ADDR_WIDTH-1:0];
+    end
 
     AXI_BUS #(
         .AXI_ADDR_WIDTH(AXI_ADDR_WIDTH),
@@ -407,7 +417,7 @@ module ariane_wrap #(
             APBBase[AXI_ADDR_WIDTH-1:0] + APBLength[AXI_ADDR_WIDTH-1:0] - 1,
             ROMBase[AXI_ADDR_WIDTH-1:0] + ROMLength[AXI_ADDR_WIDTH-1:0] - 1
         }),
-        .valid_rule_i({{NSLV} {1'b1}})
+        .valid_rule_i(axi_xbar_valid_rule)
     );
 
     // ---------------
@@ -587,7 +597,7 @@ module ariane_wrap #(
         .AXI_DATA_WIDTH ( AXI_DATA_WIDTH   ),
         .AXI_ID_WIDTH   ( AXI_ID_WIDTH_SLV ),
         .AXI_USER_WIDTH ( AXI_USER_WIDTH   ),
-        .AXI_MAX_WRITE_TXNS ( 1  ),
+        .AXI_MAX_WRITE_TXNS ( AXI_ATOMICS_MAX_WRITE_TXNS ),
         .RISCV_WORD_WIDTH   ( 64 )
     ) i_axi_riscv_atomics (
         .clk_i (clk),
@@ -786,7 +796,7 @@ module ariane_wrap #(
                 .AXI_DATA_WIDTH ( AXI_DATA_WIDTH   ),
                 .AXI_ID_WIDTH   ( AXI_ID_WIDTH_SLV ),
                 .AXI_USER_WIDTH ( AXI_USER_WIDTH   ),
-                .AXI_MAX_WRITE_TXNS ( 1  ),
+                .AXI_MAX_WRITE_TXNS ( AXI_ATOMICS_MAX_WRITE_TXNS ),
                 .RISCV_WORD_WIDTH   ( 64 )
             ) i_axi_riscv_atomics (
                 .clk_i (clk),

--- a/rtl/sockets/proxy/noc2ahbmst.vhd
+++ b/rtl/sockets/proxy/noc2ahbmst.vhd
@@ -218,8 +218,12 @@ architecture rtl of noc2ahbmst is
 
   signal serdes_current, serdes_next : serdes_fsm;
   signal sample_req, sample_rsp : std_ulogic;
+  -- Hold one extra 64-bit response beat while the SerDes emits the upper half.
+  signal load_rsp_buf, sample_rsp_buf, clear_rsp_buf : std_ulogic;
   signal req_reg : std_logic_vector(this_coh_flit_size - 1 downto 0);
   signal rsp_reg : std_logic_vector(this_coh_flit_size - 1 downto 0);
+  signal rsp_buf_reg : std_logic_vector(this_coh_flit_size - 1 downto 0);
+  signal rsp_buf_valid : std_ulogic;
 
   --attribute mark_debug : string;
   --attribute mark_debug of dma_rcv_data_out : signal is "true";
@@ -999,6 +1003,7 @@ begin  -- rtl
   serdes_gen: if narrow_noc /= 0 and ARCH_BITS /= 32 generate
 
     serdes_beh: process (serdes_current, r, ahbmi, rsp_reg, req_reg,
+                         rsp_buf_reg, rsp_buf_valid,
                          narrow_coherence_req_rdreq,
                          coherence_req_data_out,
                          coherence_req_empty,
@@ -1011,6 +1016,9 @@ begin  -- rtl
       serdes_next <= serdes_current;
       sample_rsp <= '0';
       sample_req <= '0';
+      load_rsp_buf <= '0';
+      sample_rsp_buf <= '0';
+      clear_rsp_buf <= '0';
 
       -- passthru by default
       coherence_req_rdreq           <= narrow_coherence_req_rdreq;
@@ -1023,7 +1031,23 @@ begin  -- rtl
       case serdes_current is
 
         when passthru =>
-          if r.state = send_data and r.hsize = HSIZE_DWORD and ahbmi.hready = '1' and coherence_rsp_snd_full = '0'then
+          if rsp_buf_valid = '1' and coherence_rsp_snd_full = '0' then
+            coherence_rsp_snd_wrreq <= '1';
+            wide_noc_data(this_coh_flit_size - 1 downto this_coh_flit_size - PREAMBLE_WIDTH) := PREAMBLE_BODY;
+            for i in 1 to this_coh_flit_size / 32 loop
+              wide_noc_data(32 * i - 1 downto 32 * (i - 1)) :=
+                rsp_buf_reg(31 downto 0);
+            end loop;
+            coherence_rsp_snd_data_in <= wide_noc_data;
+            load_rsp_buf <= '1';
+            if r.state = send_data and r.hsize = HSIZE_DWORD and ahbmi.hready = '1' and
+              narrow_coherence_rsp_snd_wrreq = '1' then
+              sample_rsp_buf <= '1';
+            else
+              clear_rsp_buf <= '1';
+            end if;
+            serdes_next <= rsp_msb;
+          elsif r.state = send_data and r.hsize = HSIZE_DWORD and ahbmi.hready = '1' and coherence_rsp_snd_full = '0' then
             sample_rsp <= '1';
             coherence_rsp_snd_wrreq <= '1';
             wide_noc_data(this_coh_flit_size - 1 downto this_coh_flit_size - PREAMBLE_WIDTH) := PREAMBLE_BODY;
@@ -1043,7 +1067,11 @@ begin  -- rtl
           end if;
 
         when rsp_msb =>
-          narrow_coherence_rsp_snd_full <= '1';
+          if rsp_buf_valid = '1' then
+            narrow_coherence_rsp_snd_full <= '1';
+          else
+            narrow_coherence_rsp_snd_full <= coherence_rsp_snd_full;
+          end if;
           wide_noc_data(this_coh_flit_size - 1 downto this_coh_flit_size - PREAMBLE_WIDTH) :=
             rsp_reg(this_coh_flit_size - 1 downto this_coh_flit_size - PREAMBLE_WIDTH);
           for i in 1 to this_coh_flit_size / 32 loop
@@ -1053,6 +1081,10 @@ begin  -- rtl
           coherence_rsp_snd_data_in <= wide_noc_data;
           if coherence_rsp_snd_full = '0' then
             coherence_rsp_snd_wrreq <= '1';
+            if rsp_buf_valid = '0' and r.state = send_data and r.hsize = HSIZE_DWORD and
+              ahbmi.hready = '1' and narrow_coherence_rsp_snd_wrreq = '1' then
+              sample_rsp_buf <= '1';
+            end if;
             serdes_next <= passthru;
           else
             coherence_rsp_snd_wrreq <= '0';
@@ -1080,11 +1112,21 @@ begin  -- rtl
       if rst = '0' then                   -- asynchronous reset (active low)
         serdes_current <= passthru;
         rsp_reg <= (others => '0');
+        rsp_buf_reg <= (others => '0');
+        rsp_buf_valid <= '0';
         req_reg <= (others => '0');
       elsif clk'event and clk = '1' then  -- rising clock edge
         serdes_current <= serdes_next;
         if sample_rsp = '1' then
           rsp_reg <= narrow_coherence_rsp_snd_data_in;
+        elsif load_rsp_buf = '1' then
+          rsp_reg <= rsp_buf_reg;
+        end if;
+        if sample_rsp_buf = '1' then
+          rsp_buf_reg <= narrow_coherence_rsp_snd_data_in;
+          rsp_buf_valid <= '1';
+        elsif clear_rsp_buf = '1' then
+          rsp_buf_valid <= '0';
         end if;
         if sample_req = '1' then
           req_reg <= coherence_req_data_out;

--- a/rtl/tiles/tile_cpu.vhd
+++ b/rtl/tiles/tile_cpu.vhd
@@ -21,8 +21,6 @@ use work.ibex_esp_pkg.all;
 use work.misc.all;
 -- pragma translate_off
 use work.sim.all;
-library unisim;
-use unisim.all;
 -- pragma translate_on
 use work.monitor_pkg.all;
 use work.esp_csr_pkg.all;
@@ -283,6 +281,18 @@ architecture rtl of tile_cpu is
   constant this_remote_ahb_slv_en : std_logic_vector(0 to NAHBSLV - 1) := remote_ahb_mask_cpu;
 
   constant ariane_cacheable_len : integer := (1 + CFG_L2_ENABLE) * 16#20000000#;
+
+  function set_ariane_slmddr_len
+    return std_logic_vector is
+  begin
+    if CFG_NSLMDDR_TILE = 0 then
+      return X"0000_0000_0000_0000";
+    else
+      return X"0000_0000_4000_0000";
+    end if;
+  end function;
+
+  constant ariane_slmddr_len : std_logic_vector(63 downto 0) := set_ariane_slmddr_len;
 
   attribute mark_debug : string;
 
@@ -670,7 +680,7 @@ begin
         SLMBase          => X"0000_0000_0400_0000",
         SLMLength        => X"0000_0000_0400_0000",  -- Reserving up to 64MB; devtree can set less
         SLMDDRBase       => X"0000_0000_C000_0000",
-        SLMDDRLength     => X"0000_0000_4000_0000",  -- Reserving up to 1GB; devtree can set less
+        SLMDDRLength     => ariane_slmddr_len,  -- Reserving up to 1GB; disabled when no SLMDDR tile exists
         DRAMBase         => X"0000_0000" & conv_std_logic_vector(ddr_haddr(0), 12) & X"0_0000",
         DRAMLength       => X"0000_0000_4000_0000",
         DRAMCachedLength => conv_std_logic_vector(ariane_cacheable_len, 64))  -- TODO: length set automatically to match devtree


### PR DESCRIPTION
## Summary

This PR fixes a few generic RTL corner cases found while bringing up ESP on Altera.

- Fix `noc2ahbmst` narrow-NoC response serialization so a second 64-bit AHB response beat is not lost while the SerDes is still emitting the upper half of the previous response.
- Avoid zero-width Ariane atomics bookkeeping in elaboration by using `AXI_MAX_WRITE_TXNS = 2` through a local parameter.
- Disable the Ariane SLMDDR AXI crossbar rule when no SLMDDR tile is configured, instead of leaving a valid aperture for a missing target.
- Remove an unused simulation-only `unisim` import from `tile_cpu.vhd`.