### PR TITLE
Fix RTL accelerator template generation

### DIFF
--- a/tools/accgen/accgen.sh
+++ b/tools/accgen/accgen.sh
@@ -63,6 +63,20 @@ round_up() {
     echo $(( ((x-1) | (y-1)) + 1 ))
 }
 
+rename_matches() {
+    old=$1
+    new=$2
+
+    while IFS= read -r -d '' path; do
+	dir=$(dirname "$path")
+	base=$(basename "$path")
+	new_base="${base//$old/$new}"
+	if [ "$base" != "$new_base" ]; then
+	    mv "$path" "$dir/$new_base"
+	fi
+    done < <(find . -depth -name "*${old}*" -print0)
+}
+
 declare -A values
 declare -A maxs
 
@@ -351,28 +365,14 @@ for d in $dirs; do
 	cp -r $TEMPLATES_DIR/$d/* .
     fi
 
-    if cat /etc/os-release | grep -q -i ubuntu; then
-        rename "s/accelerator/$LOWER/g" *
-	rename "s/acc_full/$LOWERFULL/g" *
-        rename "s/accelerator/$LOWER/g" */*
-	rename "s/acc_full/$LOWERFULL/g" */*
-    elif cat /etc/os-release | grep -q -i centos; then
-        rename accelerator $LOWER *
-	rename acc_full $LOWERFULL *
-        rename accelerator $LOWER */*
-	rename acc_full $LOWERFULL */*
-    elif cat /etc/os-release | grep -q -i rhel; then
-        rename accelerator $LOWER *
-	rename acc_full $LOWERFULL *
-        rename accelerator $LOWER */*
-	rename acc_full $LOWERFULL */*
-    fi
-    
+    rename_matches "accelerator" "$LOWER"
+    rename_matches "acc_full" "$LOWERFULL"
+
     if [[ "$FLOW" == "rtl" && "$d" != "hls" ]]; then
-	sed -i "s/accelerator_name/$LOWER/g" */*
-	sed -i "s/ACCELERATOR_NAME/$UPPER/g" */*
-	sed -i "s/cc_full_name/$LOWERFULL/g" */*
-	sed -i "s/ACC_FULL_NAME/$UPPERFULL/g" */*
+	find . -type f -exec sed -i "s/accelerator_name/$LOWER/g" {} +
+	find . -type f -exec sed -i "s/ACCELERATOR_NAME/$UPPER/g" {} +
+	find . -type f -exec sed -i "s/acc_full_name/$LOWERFULL/g" {} +
+	find . -type f -exec sed -i "s/ACC_FULL_NAME/$UPPERFULL/g" {} +
     elif [ "$FLOW" != "rtl" ]; then
 	find . -type f -exec sed -i "s/accelerator_name/$LOWER/g" {} +
 	find . -type f -exec sed -i "s/ACCELERATOR_NAME/$UPPER/g" {} +
@@ -736,16 +736,8 @@ for d in $dirs; do
     cd $new_dir
     cp $TEMPLATES_DIR/$d/* .
 
-    if cat /etc/os-release | grep -q -i ubuntu; then
-        rename "s/accelerator/$LOWER/g" *
-	rename "s/acc_full/$LOWERFULL/g" *
-    elif cat /etc/os-release | grep -q -i centos; then
-	rename accelerator $LOWER *
-	rename acc_full $LOWERFULL *
-    elif cat /etc/os-release | grep -q -i rhel; then
-	rename accelerator $LOWER *
-	rename acc_full $LOWERFULL *
-    fi
+    rename_matches "accelerator" "$LOWER"
+    rename_matches "acc_full" "$LOWERFULL"
 
     sed -i "s/accelerator_name/$LOWER/g" *
     sed -i "s/ACCELERATOR_NAME/$UPPER/g" *

--- a/tools/accgen/templates/rtl/src/acc_full_basic_dma32/acc_full_basic_dma32.v
+++ b/tools/accgen/templates/rtl/src/acc_full_basic_dma32/acc_full_basic_dma32.v
@@ -47,7 +47,7 @@ module acc_full_name_basic_dma32 (
     output [31:0] dma_write_ctrl_data_index;
     output [31:0] dma_write_ctrl_data_length;
     output [2:0] dma_write_ctrl_data_size;
-    output [4:0] dma_write_ctrl_data_user;
+    output [5:0] dma_write_ctrl_data_user;
 
     input dma_write_chnl_ready;
     output dma_write_chnl_valid;

--- a/tools/accgen/templates/rtl/src/acc_full_basic_dma64/acc_full_basic_dma64.v
+++ b/tools/accgen/templates/rtl/src/acc_full_basic_dma64/acc_full_basic_dma64.v
@@ -36,7 +36,7 @@ module acc_full_name_basic_dma64 (
     output [31:0] dma_read_ctrl_data_index;
     output [31:0] dma_read_ctrl_data_length;
     output [2:0] dma_read_ctrl_data_size;
-    output [4:0] dma_read_ctrl_data_user;
+    output [5:0] dma_read_ctrl_data_user;
 
     output dma_read_chnl_ready;
     input dma_read_chnl_valid;


### PR DESCRIPTION
Fixes of a bug in the RTL accelerator generation flow in `tools/accgen`.

When generating an RTL accelerator, the flow was creating the hardware-side files/folders, but the software-side folder was not generated correctly. This was caused by incomplete/fragile template renaming and placeholder substitution during accelerator generation.

Changes:
- Replaces distro-specific uses of `rename` with a shell-based `rename_matches()` helper using `find` and `mv`.
- Applies RTL placeholder substitution recursively with `find . -type f`, so nested template files are handled correctly.
- Fixes the `acc_full_name` placeholder replacement typo.
- Updates RTL DMA template `user` signal widths from 5 bits to 6 bits.
