### PR TITLE
Fix: accgen.sh for hls4ml

### DIFF
--- a/tools/accgen/accgen.sh
+++ b/tools/accgen/accgen.sh
@@ -3,8 +3,6 @@
 # Copyright (c) 2011-2026 Columbia University, System Level Design Group
 # SPDX-License-Identifier: Apache-2.0
 
-set -e
-
 ### Default
 NAME_DEFAULT="dummy"
 ESP_ROOT_DEFAULT=${PWD}


### PR DESCRIPTION
## Summary

Removed the set -e since it can cause the script to fail when renaming the accelerator in the hls4ml generator flow.