### PR TITLE
Fix: Various Bug Fixes

### DIFF
--- a/rtl/caches/llc_wrapper_axi.vhd
+++ b/rtl/caches/llc_wrapper_axi.vhd
@@ -944,7 +944,8 @@ begin  -- architecture rtl
           aw_valid <= '1';
 
           if (aw_ready = '1') then
-            reg.state := load_line;
+            -- A stalled write-address handshake must resume the write-data path.
+            reg.state := store_line;
           end if;
 
         -- LOAD LINE

--- a/rtl/cores/ariane/ariane_wrap.sv
+++ b/rtl/cores/ariane/ariane_wrap.sv
@@ -313,6 +313,9 @@ module ariane_wrap #(
     output logic                flush_done
 );
 
+    // Avoid zero-width downstream atomic bookkeeping in some elaborators.
+    localparam int AXI_ATOMICS_MAX_WRITE_TXNS = 2;
+
     // Base addresses for Ariane
     localparam ariane_pkg::ariane_cfg_t ArianeSocCfg = '{
         RASDepth: 2,
@@ -351,6 +354,13 @@ module ariane_wrap #(
         SLMDDR = 4,
         DRAM   = 5
     } axi_slaves_t;
+
+    logic [0:0][NSLV-1:0] axi_xbar_valid_rule;
+
+    always_comb begin
+        axi_xbar_valid_rule[0]         = {NSLV{1'b1}};
+        axi_xbar_valid_rule[0][SLMDDR] = |SLMDDRLength[AXI_ADDR_WIDTH-1:0];
+    end
 
     AXI_BUS #(
         .AXI_ADDR_WIDTH(AXI_ADDR_WIDTH),
@@ -407,7 +417,7 @@ module ariane_wrap #(
             APBBase[AXI_ADDR_WIDTH-1:0] + APBLength[AXI_ADDR_WIDTH-1:0] - 1,
             ROMBase[AXI_ADDR_WIDTH-1:0] + ROMLength[AXI_ADDR_WIDTH-1:0] - 1
         }),
-        .valid_rule_i({{NSLV} {1'b1}})
+        .valid_rule_i(axi_xbar_valid_rule)
     );
 
     // ---------------
@@ -587,7 +597,7 @@ module ariane_wrap #(
         .AXI_DATA_WIDTH ( AXI_DATA_WIDTH   ),
         .AXI_ID_WIDTH   ( AXI_ID_WIDTH_SLV ),
         .AXI_USER_WIDTH ( AXI_USER_WIDTH   ),
-        .AXI_MAX_WRITE_TXNS ( 1  ),
+        .AXI_MAX_WRITE_TXNS ( AXI_ATOMICS_MAX_WRITE_TXNS ),
         .RISCV_WORD_WIDTH   ( 64 )
     ) i_axi_riscv_atomics (
         .clk_i (clk),
@@ -786,7 +796,7 @@ module ariane_wrap #(
                 .AXI_DATA_WIDTH ( AXI_DATA_WIDTH   ),
                 .AXI_ID_WIDTH   ( AXI_ID_WIDTH_SLV ),
                 .AXI_USER_WIDTH ( AXI_USER_WIDTH   ),
-                .AXI_MAX_WRITE_TXNS ( 1  ),
+                .AXI_MAX_WRITE_TXNS ( AXI_ATOMICS_MAX_WRITE_TXNS ),
                 .RISCV_WORD_WIDTH   ( 64 )
             ) i_axi_riscv_atomics (
                 .clk_i (clk),

--- a/rtl/sockets/proxy/noc2ahbmst.vhd
+++ b/rtl/sockets/proxy/noc2ahbmst.vhd
@@ -218,8 +218,12 @@ architecture rtl of noc2ahbmst is
 
   signal serdes_current, serdes_next : serdes_fsm;
   signal sample_req, sample_rsp : std_ulogic;
+  -- Hold one extra 64-bit response beat while the SerDes emits the upper half.
+  signal load_rsp_buf, sample_rsp_buf, clear_rsp_buf : std_ulogic;
   signal req_reg : std_logic_vector(this_coh_flit_size - 1 downto 0);
   signal rsp_reg : std_logic_vector(this_coh_flit_size - 1 downto 0);
+  signal rsp_buf_reg : std_logic_vector(this_coh_flit_size - 1 downto 0);
+  signal rsp_buf_valid : std_ulogic;
 
   --attribute mark_debug : string;
   --attribute mark_debug of dma_rcv_data_out : signal is "true";
@@ -999,6 +1003,7 @@ begin  -- rtl
   serdes_gen: if narrow_noc /= 0 and ARCH_BITS /= 32 generate
 
     serdes_beh: process (serdes_current, r, ahbmi, rsp_reg, req_reg,
+                         rsp_buf_reg, rsp_buf_valid,
                          narrow_coherence_req_rdreq,
                          coherence_req_data_out,
                          coherence_req_empty,
@@ -1011,6 +1016,9 @@ begin  -- rtl
       serdes_next <= serdes_current;
       sample_rsp <= '0';
       sample_req <= '0';
+      load_rsp_buf <= '0';
+      sample_rsp_buf <= '0';
+      clear_rsp_buf <= '0';
 
       -- passthru by default
       coherence_req_rdreq           <= narrow_coherence_req_rdreq;
@@ -1023,7 +1031,23 @@ begin  -- rtl
       case serdes_current is
 
         when passthru =>
-          if r.state = send_data and r.hsize = HSIZE_DWORD and ahbmi.hready = '1' and coherence_rsp_snd_full = '0'then
+          if rsp_buf_valid = '1' and coherence_rsp_snd_full = '0' then
+            coherence_rsp_snd_wrreq <= '1';
+            wide_noc_data(this_coh_flit_size - 1 downto this_coh_flit_size - PREAMBLE_WIDTH) := PREAMBLE_BODY;
+            for i in 1 to this_coh_flit_size / 32 loop
+              wide_noc_data(32 * i - 1 downto 32 * (i - 1)) :=
+                rsp_buf_reg(31 downto 0);
+            end loop;
+            coherence_rsp_snd_data_in <= wide_noc_data;
+            load_rsp_buf <= '1';
+            if r.state = send_data and r.hsize = HSIZE_DWORD and ahbmi.hready = '1' and
+              narrow_coherence_rsp_snd_wrreq = '1' then
+              sample_rsp_buf <= '1';
+            else
+              clear_rsp_buf <= '1';
+            end if;
+            serdes_next <= rsp_msb;
+          elsif r.state = send_data and r.hsize = HSIZE_DWORD and ahbmi.hready = '1' and coherence_rsp_snd_full = '0' then
             sample_rsp <= '1';
             coherence_rsp_snd_wrreq <= '1';
             wide_noc_data(this_coh_flit_size - 1 downto this_coh_flit_size - PREAMBLE_WIDTH) := PREAMBLE_BODY;
@@ -1043,7 +1067,11 @@ begin  -- rtl
           end if;
 
         when rsp_msb =>
-          narrow_coherence_rsp_snd_full <= '1';
+          if rsp_buf_valid = '1' then
+            narrow_coherence_rsp_snd_full <= '1';
+          else
+            narrow_coherence_rsp_snd_full <= coherence_rsp_snd_full;
+          end if;
           wide_noc_data(this_coh_flit_size - 1 downto this_coh_flit_size - PREAMBLE_WIDTH) :=
             rsp_reg(this_coh_flit_size - 1 downto this_coh_flit_size - PREAMBLE_WIDTH);
           for i in 1 to this_coh_flit_size / 32 loop
@@ -1053,6 +1081,10 @@ begin  -- rtl
           coherence_rsp_snd_data_in <= wide_noc_data;
           if coherence_rsp_snd_full = '0' then
             coherence_rsp_snd_wrreq <= '1';
+            if rsp_buf_valid = '0' and r.state = send_data and r.hsize = HSIZE_DWORD and
+              ahbmi.hready = '1' and narrow_coherence_rsp_snd_wrreq = '1' then
+              sample_rsp_buf <= '1';
+            end if;
             serdes_next <= passthru;
           else
             coherence_rsp_snd_wrreq <= '0';
@@ -1080,11 +1112,21 @@ begin  -- rtl
       if rst = '0' then                   -- asynchronous reset (active low)
         serdes_current <= passthru;
         rsp_reg <= (others => '0');
+        rsp_buf_reg <= (others => '0');
+        rsp_buf_valid <= '0';
         req_reg <= (others => '0');
       elsif clk'event and clk = '1' then  -- rising clock edge
         serdes_current <= serdes_next;
         if sample_rsp = '1' then
           rsp_reg <= narrow_coherence_rsp_snd_data_in;
+        elsif load_rsp_buf = '1' then
+          rsp_reg <= rsp_buf_reg;
+        end if;
+        if sample_rsp_buf = '1' then
+          rsp_buf_reg <= narrow_coherence_rsp_snd_data_in;
+          rsp_buf_valid <= '1';
+        elsif clear_rsp_buf = '1' then
+          rsp_buf_valid <= '0';
         end if;
         if sample_req = '1' then
           req_reg <= coherence_req_data_out;

--- a/rtl/tiles/tile_cpu.vhd
+++ b/rtl/tiles/tile_cpu.vhd
@@ -21,8 +21,6 @@ use work.ibex_esp_pkg.all;
 use work.misc.all;
 -- pragma translate_off
 use work.sim.all;
-library unisim;
-use unisim.all;
 -- pragma translate_on
 use work.monitor_pkg.all;
 use work.esp_csr_pkg.all;
@@ -283,6 +281,18 @@ architecture rtl of tile_cpu is
   constant this_remote_ahb_slv_en : std_logic_vector(0 to NAHBSLV - 1) := remote_ahb_mask_cpu;
 
   constant ariane_cacheable_len : integer := (1 + CFG_L2_ENABLE) * 16#20000000#;
+
+  function set_ariane_slmddr_len
+    return std_logic_vector is
+  begin
+    if CFG_NSLMDDR_TILE = 0 then
+      return X"0000_0000_0000_0000";
+    else
+      return X"0000_0000_4000_0000";
+    end if;
+  end function;
+
+  constant ariane_slmddr_len : std_logic_vector(63 downto 0) := set_ariane_slmddr_len;
 
   attribute mark_debug : string;
 
@@ -670,7 +680,7 @@ begin
         SLMBase          => X"0000_0000_0400_0000",
         SLMLength        => X"0000_0000_0400_0000",  -- Reserving up to 64MB; devtree can set less
         SLMDDRBase       => X"0000_0000_C000_0000",
-        SLMDDRLength     => X"0000_0000_4000_0000",  -- Reserving up to 1GB; devtree can set less
+        SLMDDRLength     => ariane_slmddr_len,  -- Reserving up to 1GB; disabled when no SLMDDR tile exists
         DRAMBase         => X"0000_0000" & conv_std_logic_vector(ddr_haddr(0), 12) & X"0_0000",
         DRAMLength       => X"0000_0000_4000_0000",
         DRAMCachedLength => conv_std_logic_vector(ariane_cacheable_len, 64))  -- TODO: length set automatically to match devtree

--- a/soft/ariane/common/syscalls.c
+++ b/soft/ariane/common/syscalls.c
@@ -17,6 +17,9 @@ extern volatile uint64_t fromhost;
 #define NUM_COUNTERS 2
 static uintptr_t counters[NUM_COUNTERS];
 static char *counter_names[NUM_COUNTERS];
+static __thread int errno_value;
+
+int *__errno(void) { return &errno_value; }
 
 void setStats(int enable)
 {

--- a/tools/accgen/accgen.sh
+++ b/tools/accgen/accgen.sh
@@ -3,8 +3,6 @@
 # Copyright (c) 2011-2026 Columbia University, System Level Design Group
 # SPDX-License-Identifier: Apache-2.0
 
-set -e
-
 ### Default
 NAME_DEFAULT="dummy"
 ESP_ROOT_DEFAULT=${PWD}

--- a/utils/make/ariane.mk
+++ b/utils/make/ariane.mk
@@ -8,7 +8,7 @@ RISCV_TESTS = $(SOFT)/riscv-tests
 RISCV_PK = $(SOFT)/riscv-pk
 OPENSBI = $(SOFT)/opensbi
 
-soft: $(SOFT_BUILD)/prom.srec $(SOFT_BUILD)/ram.srec $(SOFT_BUILD)/prom.bin $(SOFT_BUILD)/systest.bin $(SOFT_BUILD)/ram.vhx
+soft: $(SOFT_BUILD)/prom.srec $(SOFT_BUILD)/ram.srec $(SOFT_BUILD)/prom.bin $(SOFT_BUILD)/systest.bin
 
 soft-clean:
 	$(QUIET_CLEAN)$(RM)		 	\
@@ -21,8 +21,7 @@ soft-clean:
 		$(SOFT_BUILD)/startup.o		\
 		$(SOFT_BUILD)/main.o		\
 		$(SOFT_BUILD)/uart.o		\
-		$(SOFT_BUILD)/systest.bin	\
-		$(SOFT_BUILD)/ram.vhx8
+		$(SOFT_BUILD)/systest.bin
 
 soft-distclean: soft-clean
 
@@ -89,7 +88,6 @@ RISCV_CFLAGS += -static
 RISCV_CFLAGS += -std=gnu99
 RISCV_CFLAGS += -O2
 RISCV_CFLAGS += -ffast-math
-RISCV_CFLAGS += -fno-common
 RISCV_CFLAGS += -fno-builtin-printf
 RISCV_CFLAGS += -nostdlib
 RISCV_CFLAGS += -nostartfiles -lm -lgcc
@@ -114,10 +112,6 @@ $(SOFT_BUILD)/ram.srec: $(TEST_PROGRAM)
 		python3 $(ESP_ROOT)/utils/scripts/srec/modify_srec.py $@ $(SIM_DATA_FILES) $(START_ADDRS);\
 	fi
 
-$(SOFT_BUILD)/ram.vhx: $(SOFT_BUILD)/systest.bin $(SOFT_BUILD)/vhx.bin
-
-$(SOFT_BUILD)/vhx.bin: $(TEST_PROGRAM)
-	python3 $(ESP_ROOT)/utils/scripts/file_handling/bin2txt_vhx.py 64 ariane
 
 $(SOFT_BUILD)/sysroot:
 	@mkdir -p $(SOFT_BUILD)
@@ -144,7 +138,7 @@ $(SOFT_BUILD)/linux-build/.config: $(LINUXSRC)/arch/$(ARCH)/configs/$(LINUX_CONF
 
 
 $(SOFT_BUILD)/linux-build/vmlinux: $(SOFT_BUILD)/sysroot.cpio $(SOFT_BUILD)/linux-build/.config
-	$(QUIET_MAKE) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE_LINUX) $(MAKE) -C $(SOFT_BUILD)/linux-build
+	$(QUIET_MAKE) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE_LINUX) $(MAKE) -C $(SOFT_BUILD)/linux-build KCFLAGS="-fcommon" HOSTCFLAGS="-fcommon"
 
 
 $(SOFT_BUILD)/pk-build:
@@ -232,4 +226,3 @@ VERILOG_ARIANE += $(foreach f, $(shell strings $(FLISTS)/ariane_fpga_vlog.flist)
 endif
 THIRDPARTY_VLOG += $(VERILOG_ARIANE)
 endif
-

--- a/utils/toolchain/build_riscv_toolchain.sh
+++ b/utils/toolchain/build_riscv_toolchain.sh
@@ -17,6 +17,7 @@ BUILDROOT_SHA_PYTHON=fbff7d7289cc95db991184f890f4ca1fcf8a101e
 
 # A patch for buildroot RISCV64 with numpy enabled
 BUILDROOT_PATCH=${ESP_ROOT}/utils/toolchain/python-patches/python-numpy.patch
+RISCV_NEWLIB_CMODEL=medany
 
 DEFAULT_TARGET_DIR="/home/${USER}/riscv"
 TMP=${ESP_ROOT}/_riscv_build
@@ -125,6 +126,7 @@ cd $TMP
 # Bare-metal compiler
 src=riscv-gnu-toolchain
 echo "*** Installing baremetal newlib tool chain... ***"
+echo "*** Configuring baremetal newlib with --with-cmodel=${RISCV_NEWLIB_CMODEL} for Ariane/ESP baremetal apps ***"
 if [ $(noyes "Skip ${src}") == "n" ]; then
     if test -e $src; then
 	cd $src
@@ -136,7 +138,7 @@ if [ $(noyes "Skip ${src}") == "n" ]; then
 
     git reset --hard ${RISCV_GNU_TOOLCHAIN_SHA}
     git submodule update --init --recursive
-    ./configure --prefix=${TARGET_DIR} --disable-gdb
+    ./configure --prefix=${TARGET_DIR} --disable-gdb --with-cmodel=${RISCV_NEWLIB_CMODEL}
     cmd="make -j ${NTHREADS}"
     runsudo ${TARGET_DIR} "$cmd"
 


### PR DESCRIPTION
## Summary

This PR contains several small bug fixes and cleanup changes for ESP.

## Changes
- Fix the HLS4ML generator flow by removing `set -e` which could cause the script to fail
- Fix `noc2ahbmst` narrow-NoC response serialization so the upper half of one response does not cause the next 64-bit response beat to be dropped
- Fix Ariane RTL elaboration under corner cases:
  - Avoid zero-width atomics bookkeeping by using `AXI_MAX_WRITE_TXNS = 2`
  - Disable SLMDDR AXI crossbar rule when no SLMDDR tile is configured
- Fix Ariane Linux builds with `gcc-toolset-10` or newer by explicitly preserving `-fcommon`
- Fix an LLC AXI bridge state transition so a stalled write-address handshake resumes through `store_line`
- Fixed Ariane baremetal `libm` support by building Newlib with `--with-cmodel=medany` and adding minimal Ariane baremetal `__errmo()` implementation