### PR TITLE
Fix RTL source setup and Genus Tcl generation

### DIFF
--- a/utils/make/ariane.mk
+++ b/utils/make/ariane.mk
@@ -220,16 +220,3 @@ XMLOGOPT += -DEFINE VERILATOR
 XMLOGOPT += -UNCLOCKEDSVA
 XMLOGOPT += -DEFINE WT_DCACHE=1
 
-
-### Incdir and RTL
-
-ifeq ("$(CPU_ARCH)", "ariane")
-INCDIR += $(ARIANE)/src/common_cells/include
-VERILOG_ARIANE += $(foreach f, $(shell strings $(FLISTS)/ariane_vlog.flist), $(ARIANE)/$(f))
-VERILOG_ARIANE += $(DESIGN_PATH)/$(ESP_CFG_BUILD)/plic_regmap.sv
-ifneq ($(filter $(TECHLIB),$(FPGALIBS)),)
-VERILOG_ARIANE += $(foreach f, $(shell strings $(FLISTS)/ariane_fpga_vlog.flist), $(ARIANE)/$(f))
-endif
-THIRDPARTY_VLOG += $(VERILOG_ARIANE)
-endif
-

--- a/utils/make/design.mk
+++ b/utils/make/design.mk
@@ -104,7 +104,9 @@ TOP_VHDL_RTL_PKGS += $(EXTRA_TOP_VHDL_RTL_PKGS)
 TOP_VHDL_SIM_PKGS +=
 
 TOP_VHDL_RTL_SRCS += $(DESIGN_PATH)/socketgen/accelerators.vhd
+ifeq ($(CONFIG_CACHE_EN),y)
 TOP_VHDL_RTL_SRCS += $(DESIGN_PATH)/socketgen/caches.vhd
+endif
 TOP_VHDL_RTL_SRCS += $(wildcard $(DESIGN_PATH)/socketgen/noc_*.vhd)
 TOP_VHDL_RTL_SRCS += $(DESIGN_PATH)/socketgen/tile_acc.vhd
 ifeq ($(filter $(TECHLIB),$(FPGALIBS)),)
@@ -130,9 +132,11 @@ endif
 # Testbench
 TOP_VHDL_SIM_SRCS += $(DESIGN_PATH)/$(SIMTOP).vhd
 
+ifeq ($(CONFIG_CACHE_EN),y)
 ifeq ($(TECH_TYPE),asic)
 ifneq ($(TECHLIB),inferred)
 TOP_VLOG_RTL_SRCS += $(DESIGN_PATH)/cache_def_mem_asic.sv
+endif
 endif
 endif
 

--- a/utils/make/genus.mk
+++ b/utils/make/genus.mk
@@ -8,9 +8,27 @@ GENUS_EXCLUDE_VLOG += $(ESP_ROOT)/rtl/cores/ariane/ariane/src/util/instr_trace_i
 GENUS_EXCLUDE_VLOG += $(ESP_ROOT)/rtl/cores/ariane/ariane/src/util/instr_tracer_if.sv
 GENUS_EXCLUDE_VLOG += $(ESP_ROOT)/rtl/cores/ariane/ariane/src/util/instr_tracer.sv
 GENUS_EXCLUDE_VLOG += $(ESP_ROOT)/rtl/cores/ibex/ibex/vendor/lowrisc_ip/ip/prim_xilinx/rtl/prim_xilinx_clock_gating.sv
+GENUS_EXCLUDE_VLOG += $(ESP_ROOT)/rtl/techmap/virtex%
 
 GENUS_EXCLUDE_VHDL += $(ESP_ROOT)/rtl/sockets/monitor/monitor.vhd
+GENUS_EXCLUDE_VHDL += $(ESP_ROOT)/rtl/sim/%
+GENUS_EXCLUDE_VHDL += $(ESP_ROOT)/rtl/sockets/jtag/jtag_tb.vhd
+GENUS_EXCLUDE_VHDL += $(ESP_ROOT)/rtl/sockets/jtag/fpga_proxy_jtag.vhd
+GENUS_EXCLUDE_VHDL += $(ESP_ROOT)/rtl/peripherals/ddr/%_profpga.vhd
+GENUS_EXCLUDE_VHDL += $(ESP_ROOT)/rtl/techmap/virtex%
 GENUS_EXCLUDE_VHDL += $(DESIGN_PATH)/fpga_proxy_top.vhd
+GENUS_EXCLUDE_VHDL += $(DESIGN_PATH)/chip_emu_top.vhd
+GENUS_EXCLUDE_VHDL += $(DESIGN_PATH)/top.vhd
+GENUS_EXCLUDE_VHDL += $(DESIGN_PATH)/testbench.vhd
+
+GENUS_EXCLUDE_INCDIR += $(PROFPGA)/hdl/%
+GENUS_EXCLUDE_INCDIR += $(ESP_ROOT)/rtl/peripherals/bsg/testing/%
+
+GENUS_HDL_SEARCH_PATH = $(filter-out $(GENUS_EXCLUDE_INCDIR),$(INCDIR) $(BSG_INCDIR))
+GENUS_VHDL_PKGS = $(filter-out $(GENUS_EXCLUDE_VHDL),$(VHDL_PKGS))
+GENUS_VHDL_SRCS = $(filter-out $(GENUS_EXCLUDE_VHDL),$(VHDL_SRCS))
+GENUS_VLOG_SRCS = $(filter-out $(GENUS_EXCLUDE_VLOG),$(VLOG_SRCS))
+GENUS_BSG_VLOG_SRCS = $(filter-out $(ESP_ROOT)/rtl/peripherals/bsg/testing/%,$(BSG_VLOG_SRCS))
 
 
 ### Genus targets ###

--- a/utils/make/genus.mk
+++ b/utils/make/genus.mk
@@ -42,34 +42,38 @@ genus:
 
 genus/incdir.tcl: genus $(RTL_CFG_BUILD)/check_all_rtl_srcs.old
 	$(QUIET_MAKE) \
-	echo "set DES(hdl_search_path) \"$(INCDIR) $(BSG_INCDIR)\"" > $@
+	{ \
+		echo "set DES(hdl_search_path) [list \\"; \
+		for dir in $(GENUS_HDL_SEARCH_PATH); do \
+			printf '    "%s" \\\n' "$$dir"; \
+		done; \
+		echo "]"; \
+	} > $@
 
 genus/srcs.tcl: genus $(RTL_CFG_BUILD)/check_all_rtl_srcs.old
 	$(QUIET_MAKE) $(RM) $@
 	@echo "### Compile VHDL packages ###" >> $@; \
-	for vhd in $(VHDL_PKGS); do \
+	for vhd in $(GENUS_VHDL_PKGS); do \
 		rtl=$$vhd; \
 		echo "$(GENUS_VHDL) $$rtl" >> $@; \
 	done; \
 	echo "### Compile VHDL source files ###" >> $@; \
-	for rtl in $(VHDL_SRCS); do \
-		if echo "$(GENUS_EXCLUDE_VHDL)" | grep -q $$rtl; then \
-			echo "# skip $$rtl" >> $@; \
-		else \
-			[[ $$rtl =~ techmap/virtex  ]] || echo "$(GENUS_VHDL) $$rtl" >> $@; \
-		fi; \
+	for rtl in $(GENUS_VHDL_SRCS); do \
+		echo "$(GENUS_VHDL) $$rtl" >> $@; \
 	done; \
 	echo "### Compile Verilog source files ###" >> $@; \
-	for rtl in $(VLOG_SRCS); do \
-		if echo "$(GENUS_EXCLUDE_VLOG)" | grep -q $$rtl; then \
-			echo "# skip $$rtl" >> $@; \
-		else \
-			[[ $$rtl =~ techmap/virtex  ]] || echo "$(GENUS_VLOG) $$rtl" >> $@; \
-		fi; \
+	for rtl in $(GENUS_VLOG_SRCS); do \
+		echo "$(GENUS_VLOG) $$rtl" >> $@; \
 	done;
 ifneq ("$(wildcard $(ESP_ROOT)/rtl/peripherals/bsg/.git)", "")
 	@echo "### Compile BSG Verilog source files ###" >> $@; \
-	echo "$(GENUS_VLOG) $(GENUS_BSG_VLOGOPT) $(BSG_VLOG_SRCS)" >> $@;
+	{ \
+		printf '%s %s' "$(GENUS_VLOG)" "$(GENUS_BSG_VLOGOPT)"; \
+		for rtl in $(GENUS_BSG_VLOG_SRCS); do \
+			printf ' \\\n    "%s"' "$$rtl"; \
+		done; \
+		printf '\n'; \
+	} >> $@;
 endif
 
 genus/$(DESIGN): genus genus/srcs.tcl genus/incdir.tcl

--- a/utils/make/rtl.mk
+++ b/utils/make/rtl.mk
@@ -16,7 +16,7 @@ SIM_VHDL_PKGS += $(THIRDPARTY_VHDL_PKGS)
 SIM_VHDL_PKGS += $(TOP_VHDL_RTL_PKGS) $(TOP_VHDL_SIM_PKGS)
 
 VHDL_PKGS += $(SOCKETGEN_VHDL_RTL_PKGS)
-VHDL_PKGS += $(foreach f, $(shell strings $(FLISTS)/vhdl_pkgs.flist), $(if $(findstring rtl/sim, $(f)),, $(ESP_ROOT)/rtl/$(f)))
+VHDL_PKGS += $(foreach f, $(filter-out sim/%,$(shell strings $(FLISTS)/vhdl_pkgs.flist)), $(ESP_ROOT)/rtl/$(f))
 VHDL_PKGS += $(THIRDPARTY_VHDL_PKGS)
 VHDL_PKGS += $(TOP_VHDL_RTL_PKGS)
 

--- a/utils/make/rtl.mk
+++ b/utils/make/rtl.mk
@@ -9,19 +9,42 @@ INCDIR += $(DESIGN_PATH)/$(ESP_CFG_BUILD)
 INCDIR += $(THIRDPARTY_INCDIR)
 INCDIR += $(ESP_ROOT)/rtl/caches/esp-caches/common/defs
 
+### Configuration-specific RTL exclusions ###
+CACHE_VHDL_PKG_EXCLUDES =
+CACHE_VHDL_SRC_EXCLUDES =
+CACHE_VLOG_EXCLUDES =
+TECHMAP_VLOG_EXCLUDES =
+
+ifneq ($(CONFIG_CACHE_EN),y)
+CACHE_VHDL_PKG_EXCLUDES += caches/gencaches.vhd
+CACHE_VHDL_SRC_EXCLUDES += caches/l2_wrapper.vhd
+CACHE_VHDL_SRC_EXCLUDES += caches/llc_wrapper.vhd
+CACHE_VHDL_SRC_EXCLUDES += caches/llc_wrapper_axi.vhd
+CACHE_VHDL_SRC_EXCLUDES += caches/l2_acc_wrapper.vhd
+CACHE_VHDL_SRC_EXCLUDES += caches/fifo_custom.vhd
+CACHE_VLOG_EXCLUDES += caches/esp-caches/%
+TECHMAP_VLOG_EXCLUDES += techmap/asic/mem/L2_SRAM_%
+TECHMAP_VLOG_EXCLUDES += techmap/asic/mem/LLC_SRAM_%
+endif
+
+ifneq ($(CPU_ARCH),ariane)
+TECHMAP_VLOG_EXCLUDES += techmap/asic/mem/L1_SRAM_SP.v
+TECHMAP_VLOG_EXCLUDES += techmap/asic/SyncSpRamBeNx64.sv
+endif
+
 ## VHDL Packages
 SIM_VHDL_PKGS += $(SOCKETGEN_VHDL_RTL_PKGS)
-SIM_VHDL_PKGS += $(foreach f, $(shell strings $(FLISTS)/vhdl_pkgs.flist), $(ESP_ROOT)/rtl/$(f))
+SIM_VHDL_PKGS += $(foreach f, $(filter-out $(CACHE_VHDL_PKG_EXCLUDES),$(shell strings $(FLISTS)/vhdl_pkgs.flist)), $(ESP_ROOT)/rtl/$(f))
 SIM_VHDL_PKGS += $(THIRDPARTY_VHDL_PKGS)
 SIM_VHDL_PKGS += $(TOP_VHDL_RTL_PKGS) $(TOP_VHDL_SIM_PKGS)
 
 VHDL_PKGS += $(SOCKETGEN_VHDL_RTL_PKGS)
-VHDL_PKGS += $(foreach f, $(filter-out sim/%,$(shell strings $(FLISTS)/vhdl_pkgs.flist)), $(ESP_ROOT)/rtl/$(f))
+VHDL_PKGS += $(foreach f, $(filter-out sim/% $(CACHE_VHDL_PKG_EXCLUDES),$(shell strings $(FLISTS)/vhdl_pkgs.flist)), $(ESP_ROOT)/rtl/$(f))
 VHDL_PKGS += $(THIRDPARTY_VHDL_PKGS)
 VHDL_PKGS += $(TOP_VHDL_RTL_PKGS)
 
 ## VHDL Source
-VHDL_SRCS += $(foreach f, $(shell strings $(FLISTS)/vhdl.flist), $(ESP_ROOT)/rtl/$(f))
+VHDL_SRCS += $(foreach f, $(filter-out $(CACHE_VHDL_SRC_EXCLUDES),$(shell strings $(FLISTS)/vhdl.flist)), $(ESP_ROOT)/rtl/$(f))
 VHDL_SRCS += $(foreach f, $(shell strings $(FLISTS)/cores_vhdl.flist), $(if $(findstring cores/$(CPU_ARCH), $(f)), $(ESP_ROOT)/rtl/$(f),))
 
 ifeq ($(TECHLIB), inferred)
@@ -60,15 +83,15 @@ RTL_TECH_FOLDERS = $(shell ls -d $(ESP_ROOT)/tech/$(TECHLIB)/*/)
 
 VLOG_SRCS += $(DESIGN_PATH)/$(ESP_CFG_BUILD)/esp_global_sv.sv
 
-VLOG_SRCS += $(foreach f, $(shell strings $(FLISTS)/vlog.flist), $(ESP_ROOT)/rtl/$(f))
+VLOG_SRCS += $(foreach f, $(filter-out $(CACHE_VLOG_EXCLUDES),$(shell strings $(FLISTS)/vlog.flist)), $(ESP_ROOT)/rtl/$(f))
 VLOG_SRCS += $(foreach f, $(shell strings $(FLISTS)/cores_vlog.flist), $(if $(findstring cores/$(CPU_ARCH), $(f)), $(ESP_ROOT)/rtl/$(f),))
 
 ifeq ($(TECHLIB), inferred)
-VLOG_SRCS += $(foreach f, $(shell strings $(FLISTS)/techmap_vlog.flist), $(if $(findstring techmap/$(TECHLIB), $(f)), $(ESP_ROOT)/rtl/$(f),))
+VLOG_SRCS += $(foreach f, $(filter-out $(TECHMAP_VLOG_EXCLUDES),$(shell strings $(FLISTS)/techmap_vlog.flist)), $(if $(findstring techmap/$(TECHLIB), $(f)), $(ESP_ROOT)/rtl/$(f),))
 else ifeq ($(TECH_TYPE), asic)
-VLOG_SRCS += $(foreach f, $(shell strings $(FLISTS)/techmap_vlog.flist), $(if $(findstring techmap/asic, $(f)), $(ESP_ROOT)/rtl/$(f),))
+VLOG_SRCS += $(foreach f, $(filter-out $(TECHMAP_VLOG_EXCLUDES),$(shell strings $(FLISTS)/techmap_vlog.flist)), $(if $(findstring techmap/asic, $(f)), $(ESP_ROOT)/rtl/$(f),))
 else
-VLOG_SRCS += $(foreach f, $(shell strings $(FLISTS)/techmap_vlog.flist), $(if $(findstring techmap/$(TECHLIB), $(f)), $(ESP_ROOT)/rtl/$(f),))
+VLOG_SRCS += $(foreach f, $(filter-out $(TECHMAP_VLOG_EXCLUDES),$(shell strings $(FLISTS)/techmap_vlog.flist)), $(if $(findstring techmap/$(TECHLIB), $(f)), $(ESP_ROOT)/rtl/$(f),))
 endif
 
 ifeq ($(CONFIG_HAS_DVFS),y)


### PR DESCRIPTION
## Summary
- Consolidated Ariane RTL source setup
- Filtered unsupported or unused Genus RTL inputs
- Improve generated Genus Tcl readability for include dirs and BSG Verilog sources

---

## Notes
I noticed that the RTL sources for Genus related to Ariane were generated 4 times. Additionally, to prevent warnings related to simulation RTL files and testbenches, I decided it was the case to filter some unused RTL from the `flist`. In the end, for improving readability, I decided to perform line splitting in long, single lines. 
