### PR TITLE
Fix Inferred Latch in MEM Tile

### DIFF
--- a/rtl/sockets/proxy/mem2ext.vhd
+++ b/rtl/sockets/proxy/mem2ext.vhd
@@ -365,6 +365,7 @@ begin  -- architecture rtl
     llc_ext_rsp_valid <= '0';
     dma_rcv_rdreq <= '0';
     dma_snd_wrreq <= '0';
+    dma_snd_data_in <= (others => '0');
 
     llc_ext_rsp_data <= ext_rcv_data_out;
 


### PR DESCRIPTION
## Summary

Added a full-vector default assignment in `mem2ext.vhd`:
```
  dma_snd_data_in <= (others => '0');
```

This ensures every combinational path drives the output while preserving later header and payload overrides.

---

##  Motivation
In ESP's Memory Tile, in the file `mem2ext.vhd`, a default assignment was missing, causing an inferred latch during synthesis.