### PR TITLE
contig_alloc: make DMA handles opaque and reference counted

### DIFF
--- a/soft/common/drivers/linux/contig_alloc/contig_alloc.c
+++ b/soft/common/drivers/linux/contig_alloc/contig_alloc.c
@@ -22,9 +22,12 @@
 #include <linux/compiler.h>
 #include <linux/device.h>
 #include <linux/kernel.h>
+#include <linux/kref.h>
 #include <linux/module.h>
 #include <linux/mutex.h>
 #include <linux/list.h>
+#include <linux/random.h>
+#include <linux/sched/mm.h>
 #include <linux/slab.h>
 #include <linux/stat.h>
 #include <linux/err.h>
@@ -41,6 +44,7 @@ struct contig_chunk {
 };
 
 struct contig_file {
+    struct mutex lock;
     struct list_head desc_list;
 };
 
@@ -86,6 +90,10 @@ static struct contig_desc *contig_alloc_descriptor(unsigned int n_chunks)
     desc = kmalloc(sizeof(*desc), GFP_KERNEL);
     if (unlikely(desc == NULL)) return ERR_PTR(-ENOMEM);
 
+    desc->khandle  = 0;
+    desc->owner_mm = NULL;
+    kref_init(&desc->refcount);
+
     desc->arr = kmalloc_array(n_chunks, sizeof(unsigned long), GFP_KERNEL);
     if (unlikely(desc->arr == NULL)) goto err_arr;
 
@@ -113,6 +121,7 @@ static void contig_free_descriptor(struct contig_desc *desc)
 #ifndef __riscv
     dma_unmap_single(NULL, desc->arr_dma_addr, desc->n * sizeof(dma_addr_t), DMA_TO_DEVICE);
 #endif
+    if (desc->owner_mm) mmdrop(desc->owner_mm);
     kfree(desc->arr);
     kfree(desc);
 }
@@ -350,31 +359,74 @@ void __contig_free(struct contig_desc *desc)
     contig_free_descriptor(desc);
 }
 
-void contig_free(struct contig_desc *desc)
+static void contig_desc_release(struct kref *ref)
 {
+    struct contig_desc *desc = container_of(ref, struct contig_desc, refcount);
+
     mutex_lock(&contig_lock);
     __contig_free(desc);
     mutex_unlock(&contig_lock);
 }
+
+void contig_desc_put(struct contig_desc *desc) { kref_put(&desc->refcount, contig_desc_release); }
+EXPORT_SYMBOL_GPL(contig_desc_put);
+
+void contig_free(struct contig_desc *desc) { contig_desc_put(desc); }
 EXPORT_SYMBOL_GPL(contig_free);
 
-/*
- * Check that this is a valid desc. Ideally we'd also make sure that the calling
- * process owns the contig buffer. But for now this will do.
- */
+static bool contig_khandle_exists(unsigned long khandle)
+{
+    struct contig_desc *desc;
+
+    list_for_each_entry(desc, &desc_list, desc_node) if (desc->khandle == khandle) return true;
+    return false;
+}
+
+static int contig_desc_publish(struct contig_desc *desc, contig_khandle_t *khandle)
+{
+    unsigned long value;
+
+    if (unlikely(!current->mm)) return -EINVAL;
+
+    mmgrab(current->mm);
+    mutex_lock(&contig_lock);
+    do {
+        value = get_random_long();
+    } while (!value || contig_khandle_exists(value));
+    desc->owner_mm = current->mm;
+    desc->khandle  = value;
+    mutex_unlock(&contig_lock);
+
+    *khandle = (contig_khandle_t)value;
+    return 0;
+}
+
+static void contig_desc_unpublish(struct contig_desc *desc)
+{
+    mutex_lock(&contig_lock);
+    desc->khandle = 0;
+    mutex_unlock(&contig_lock);
+}
+
 struct contig_desc *contig_khandle_to_desc(contig_khandle_t khandle)
 {
-    struct contig_desc *handle = (struct contig_desc *)khandle;
-    struct contig_desc *desc;
+    unsigned long value = (unsigned long)khandle;
+    struct contig_desc *desc, *ret = NULL;
+
+    if (!value || unlikely(!current->mm)) return NULL;
 
     mutex_lock(&contig_lock);
     list_for_each_entry(desc, &desc_list, desc_node)
     {
-        if (desc == handle) break;
+        if (desc->khandle == value && desc->owner_mm == current->mm) {
+            kref_get(&desc->refcount);
+            ret = desc;
+            break;
+        }
     }
     mutex_unlock(&contig_lock);
 
-    return desc == handle ? desc : NULL;
+    return ret;
 }
 EXPORT_SYMBOL_GPL(contig_khandle_to_desc);
 
@@ -449,6 +501,7 @@ static int contig_open(struct inode *inode, struct file *file)
 
     priv = kmalloc(sizeof(*priv), GFP_KERNEL);
     if (priv == NULL) return -ENOMEM;
+    mutex_init(&priv->lock);
     INIT_LIST_HEAD(&priv->desc_list);
     file->private_data = priv;
     return 0;
@@ -459,11 +512,14 @@ static int contig_release(struct inode *inode, struct file *file)
     struct contig_file *priv = file->private_data;
     struct contig_desc *desc, *nxt;
 
+    mutex_lock(&priv->lock);
     list_for_each_entry_safe(desc, nxt, &priv->desc_list, file_node)
     {
         list_del(&desc->file_node);
-        contig_free(desc);
+        contig_desc_unpublish(desc);
+        contig_desc_put(desc);
     }
+    mutex_unlock(&priv->lock);
     kfree(priv);
     return 0;
 }
@@ -513,38 +569,51 @@ static long contig_alloc_ioctl(struct file *file, void __user *arg)
         contig_free(desc);
         return -EFAULT;
     }
-    req.n              = desc->n;
-    req.khandle        = (contig_khandle_t)desc;
-    req.most_allocated = desc->most_allocated;
-    if (copy_to_user(arg, &req, sizeof(req))) {
+    req.n = desc->n;
+    if (contig_desc_publish(desc, &req.khandle)) {
         contig_free(desc);
+        return -EINVAL;
+    }
+    req.most_allocated = desc->most_allocated;
+
+    mutex_lock(&priv->lock);
+    list_add(&desc->file_node, &priv->desc_list);
+    mutex_unlock(&priv->lock);
+
+    if (copy_to_user(arg, &req, sizeof(req))) {
+        mutex_lock(&priv->lock);
+        list_del(&desc->file_node);
+        mutex_unlock(&priv->lock);
+        contig_desc_unpublish(desc);
+        contig_desc_put(desc);
         return -EFAULT;
     }
-    list_add(&desc->file_node, &priv->desc_list);
     return 0;
 }
 
 static long contig_free_ioctl(struct file *file, contig_khandle_t __user *arg)
 {
     struct contig_file *priv = file->private_data;
-    struct contig_desc *del, *desc, *next;
+    struct contig_desc *desc, *next;
     contig_khandle_t del_addr;
     bool found = false;
 
     if (get_user(del_addr, arg)) return -EFAULT;
-    del = (struct contig_desc *)del_addr;
 
     /* is it a valid descriptor for this file? */
+    mutex_lock(&priv->lock);
     list_for_each_entry_safe(desc, next, &priv->desc_list, file_node)
     {
-        if (desc == del) {
-            list_del(&del->file_node);
+        if (desc->khandle == (unsigned long)del_addr) {
+            list_del(&desc->file_node);
             found = true;
             break;
         }
     }
+    mutex_unlock(&priv->lock);
     if (!found) return -EFAULT;
-    contig_free(del);
+    contig_desc_unpublish(desc);
+    contig_desc_put(desc);
     return 0;
 }
 
@@ -569,6 +638,20 @@ static long contig_ioctl(struct file *file, unsigned int cm, unsigned long arg)
     return contig_do_ioctl(file, cm, (void __user *)arg);
 }
 
+static void contig_vma_open(struct vm_area_struct *vma)
+{
+    struct contig_desc *desc = vma->vm_private_data;
+
+    kref_get(&desc->refcount);
+}
+
+static void contig_vma_close(struct vm_area_struct *vma) { contig_desc_put(vma->vm_private_data); }
+
+static const struct vm_operations_struct contig_vm_ops = {
+    .open  = contig_vma_open,
+    .close = contig_vma_close,
+};
+
 static int contig_mmap(struct file *file, struct vm_area_struct *vma)
 {
     int i, rc;
@@ -577,30 +660,38 @@ static int contig_mmap(struct file *file, struct vm_area_struct *vma)
     long unsigned paddr      = PFN_PHYS(vma->vm_pgoff);
     bool found               = false;
 
-    mutex_lock(&contig_lock);
+    mutex_lock(&priv->lock);
     list_for_each_entry(itr, &priv->desc_list, file_node)
     {
         if (itr->arr[0] == paddr) {
             found = true;
             desc  = itr;
+            kref_get(&desc->refcount);
             break;
         }
     }
-    mutex_unlock(&contig_lock);
+    mutex_unlock(&priv->lock);
 
     if (!found) {
         pr_info("contig_alloc: descriptor for addres %08lX not found", paddr);
         return -EFAULT;
     }
 
-    vma->vm_page_prot = pgprot_noncached(vma->vm_page_prot);
+    vma->vm_ops          = &contig_vm_ops;
+    vma->vm_private_data = desc;
+    vma->vm_page_prot    = pgprot_noncached(vma->vm_page_prot);
 
     for (i = 0; i < desc->n; i++) {
         /* pr_info("contig_mmap: paddr[%d] = %08lX\n", i, desc->arr[i]); */
         rc = remap_pfn_range(vma, vma->vm_start + i * chunk_size, PHYS_PFN(desc->arr[i]),
                              chunk_size, vma->vm_page_prot);
 
-        if (rc) return rc;
+        if (rc) {
+            vma->vm_ops          = NULL;
+            vma->vm_private_data = NULL;
+            contig_desc_put(desc);
+            return rc;
+        }
     }
 
     return 0;
@@ -683,7 +774,11 @@ static void contig_exit(void)
 {
     struct contig_desc *desc, *nxt;
 
-    list_for_each_entry_safe(desc, nxt, &desc_list, desc_node) { __contig_free(desc); }
+    list_for_each_entry_safe(desc, nxt, &desc_list, desc_node)
+    {
+        desc->khandle = 0;
+        __contig_free(desc);
+    }
     __contig_chunks_remove();
     contig_phys_free();
     contig_remove_file();

--- a/soft/common/drivers/linux/esp/esp.c
+++ b/soft/common/drivers/linux/esp/esp.c
@@ -373,7 +373,7 @@ static long esp_yx_table_init(struct esp_device *esp, struct esp_access *access)
 
 static int esp_access_ioctl(struct esp_device *esp, void __user *argp)
 {
-    struct contig_desc *contig;
+    struct contig_desc *contig = NULL;
     struct esp_access *access;
     void *arg;
     int rc = 0;
@@ -459,6 +459,7 @@ static int esp_access_ioctl(struct esp_device *esp, void __user *argp)
     mutex_unlock(&esp->lock);
 
 out:
+    if (contig) contig_desc_put(contig);
     kfree(arg);
     return rc;
 }

--- a/soft/common/drivers/linux/include/contig_alloc.h
+++ b/soft/common/drivers/linux/include/contig_alloc.h
@@ -100,6 +100,7 @@ struct contig_alloc_req {
 
 #ifdef __KERNEL__
 
+    #include <linux/kref.h>
     #include <linux/list.h>
 
 struct contig_desc {
@@ -107,6 +108,9 @@ struct contig_desc {
     dma_addr_t arr_dma_addr;
     unsigned int n;
     int most_allocated;
+    unsigned long khandle;
+    struct mm_struct *owner_mm;
+    struct kref refcount;
     struct list_head desc_node;
     struct list_head file_node;
     struct list_head alloc_list;
@@ -116,6 +120,7 @@ extern struct contig_desc *contig_alloc(const struct contig_alloc_params *params
                                         unsigned long size);
 extern void contig_free(struct contig_desc *desc);
 extern struct contig_desc *contig_khandle_to_desc(contig_khandle_t khandle);
+extern void contig_desc_put(struct contig_desc *desc);
 
 extern unsigned long contig_chunk_size_log;
 


### PR DESCRIPTION
## Summary

Replace pointer-valued contiguous-buffer handles with random opaque values bound to the allocating address space.

Serialize each open allocator file's descriptor list. Hold descriptor references across accelerator access plus VMA lifetime, then invalidate the handle before dropping the allocation reference.

## Rationale

`CONTIG_IOC_ALLOC` returned the exact `struct contig_desc *` address. The global handle lookup accepted that pointer from another address space and returned it without a lifetime reference.

Those contracts exposed a kernel heap address, admitted cross-process DMA-buffer selection and allowed concurrent access/free or mmap/free paths to consume released descriptor state. Concurrent free ioctls could also pass the same unlocked per-file membership check.

## Impact

The userspace ABI width is unchanged because `contig_khandle_t` remains pointer-shaped. The value is now an opaque token with no descriptor-address relationship.

Accelerator lookup accepts a live token only from the allocation's address space. Free removes the token from lookup visibility immediately; the backing descriptor and chunks remain alive until active accelerator users plus VMAs release their references.

## Validation

- Built `contig_alloc.ko` against Ubuntu Linux 5.15 arm64 headers.
- An AddressSanitizer-backed harness drives the real allocation, lookup, free, ESP access and mmap paths.
- Allocation returns a value distinct from the descriptor address.
- Lookup from another `mm_struct` returns `-EFAULT` without programming `PT_ADDRESS_REG`.
- Two concurrent frees produce one success plus one `-EFAULT`.
- Access and VMA references defer descriptor release until their final put/close.

```text
OPAQUE_HANDLE=1 CROSS_MM_REJECTED=1 DUP_FREE_SERIALIZED=1 ACCESS_REF_HELD=1 ACCESS_IOCTL_OWNER_CHECKED=1 VMA_REF_HELD=1
```
