### PR TITLE
Add behavioral DCO fallback for ASIC RTL simulation

### DIFF
--- a/rtl/sockets/dvfs/behav_dco.v
+++ b/rtl/sockets/dvfs/behav_dco.v
@@ -41,13 +41,44 @@ module behav_dco (
 
 
     reg  [255:0] clk_int;
+    reg  [  6:0] divider_count;
+    reg          divided_clk;
     wire [  7:0] LDO_IN;
+    wire [  7:0] LDO_IN_with_U_forced_to_0;
+    wire         enabled;
+    wire         oscillator_clk;
+    wire         selected_clk;
 
     assign LDO_IN[7:6] = FREQ_SEL;
     assign LDO_IN[5:0] = CC_SEL;
-    wire LDO_IN_with_U_forced_to_0 = (LDO_IN === 8'bXXXXXXXX || LDO_IN === 8'bZZZZZZZZ) ? 8'b00000000 : LDO_IN;
-    assign CLK     = clk_int[unsigned'(LDO_IN_with_U_forced_to_0)];
-    assign CLK_DIV = 1'b0;
+    assign LDO_IN_with_U_forced_to_0 =
+        (^LDO_IN === 1'bx) ? 8'b00000000 : LDO_IN;
+    assign enabled        = (RSTN === 1'b1) && (EN === 1'b1);
+    assign oscillator_clk = clk_int[unsigned'(LDO_IN_with_U_forced_to_0)];
+    assign selected_clk   = (CLK_SEL === 1'b1) ? EXT_CLK : oscillator_clk;
+    assign CLK            = enabled ? selected_clk : 1'b0;
+    assign CLK_DIV        = enabled ? divided_clk : 1'b0;
+
+    always @(posedge selected_clk or negedge RSTN or negedge EN) begin
+        if (!RSTN || !EN)
+            divider_count <= 7'b0;
+        else
+            divider_count <= divider_count + 1'b1;
+    end
+
+    always @* begin
+        case (DIV_SEL)
+            3'd0: divided_clk = selected_clk;
+            3'd1: divided_clk = divider_count[0];
+            3'd2: divided_clk = divider_count[1];
+            3'd3: divided_clk = divider_count[2];
+            3'd4: divided_clk = divider_count[3];
+            3'd5: divided_clk = divider_count[4];
+            3'd6: divided_clk = divider_count[5];
+            3'd7: divided_clk = divider_count[6];
+            default: divided_clk = 1'b0;
+        endcase
+    end
 
     localparam TIME_PERIOD = 10;
     localparam TIME_PERIOD_HALF = TIME_PERIOD / 2;
@@ -319,12 +350,90 @@ module behav_dco (
             localparam TIME_PERIODI = 8.0 * DELAYS[i] / 2.0;
             initial begin
                 clk_int[i] = 0;
-                forever #TIME_PERIODI clk_int[i] = (~clk_int[i]) && EN;
+                forever #TIME_PERIODI clk_int[i] = (~clk_int[i]) && enabled;
             end
         end
     endgenerate
 
 
 endmodule
+
+// ASIC RTL simulations use these compatibility wrappers when the structural
+// DCO or its timing data is unavailable.  Synthesis never defines this macro.
+`ifdef ASIC_DCO_BEHAV_FALLBACK
+module DCO_ASIC (
+    input  wire       EN,
+    input  wire [5:0] CC_SEL,
+    input  wire [5:0] FC_SEL,
+    input  wire       EXT_CLK,
+    input  wire       CLK_SEL,
+    input  wire [2:0] DIV_SEL,
+    input  wire [1:0] FREQ_SEL,
+    output wire       CLK,
+    output wire       CLK_DIV,
+    input  wire       RSTN
+);
+    behav_dco dco_i (
+        .EN(EN),
+        .CC_SEL(CC_SEL),
+        .FC_SEL(FC_SEL),
+        .EXT_CLK(EXT_CLK),
+        .CLK_SEL(CLK_SEL),
+        .DIV_SEL(DIV_SEL),
+        .FREQ_SEL(FREQ_SEL),
+        .CLK(CLK),
+        .CLK_DIV(CLK_DIV),
+        .RSTN(RSTN)
+    );
+endmodule
+
+module DCO_LPDDR (
+    input  wire       EN,
+    input  wire [5:0] CC_SEL,
+    input  wire [5:0] FC_SEL,
+    input  wire       EXT_CLK,
+    input  wire       CLK_SEL,
+    input  wire [2:0] DIV_SEL,
+    input  wire [1:0] FREQ_SEL,
+    output wire       CLK,
+    output wire       CLK_DIV2,
+    output wire       CLK_DIV2_90,
+    output wire       CLK_DIV,
+    input  wire       RSTN
+);
+    reg clk_div2_r;
+    reg clk_div2_90_r;
+
+    behav_dco dco_i (
+        .EN(EN),
+        .CC_SEL(CC_SEL),
+        .FC_SEL(FC_SEL),
+        .EXT_CLK(EXT_CLK),
+        .CLK_SEL(CLK_SEL),
+        .DIV_SEL(DIV_SEL),
+        .FREQ_SEL(FREQ_SEL),
+        .CLK(CLK),
+        .CLK_DIV(CLK_DIV),
+        .RSTN(RSTN)
+    );
+
+    always @(posedge CLK or negedge RSTN or negedge EN) begin
+        if (!RSTN || !EN)
+            clk_div2_r <= 1'b0;
+        else
+            clk_div2_r <= ~clk_div2_r;
+    end
+
+    always @(negedge CLK or negedge RSTN or negedge EN) begin
+        if (!RSTN || !EN)
+            clk_div2_90_r <= 1'b0;
+        else
+            clk_div2_90_r <= ~clk_div2_90_r;
+    end
+
+    assign CLK_DIV2    = clk_div2_r;
+    assign CLK_DIV2_90 = clk_div2_90_r;
+endmodule
+`endif
 
 //`default_nettype wire

--- a/socs/esp_asic_generic/Makefile
+++ b/socs/esp_asic_generic/Makefile
@@ -112,6 +112,83 @@ ESPLINK_PORT ?= 46392
 ### Include global Makefile ###
 include $(ESP_ROOT)/utils/Makefile
 
+### DCO model selection for ModelSim RTL simulation ###
+# Structural timing simulation is preferred when the core DCO sources and its
+# SDF are present.  LPDDR and delay-line sources are optional because the
+# generated ASIC top does not elaborate them for normal tiles.  The behavioral
+# fallback reuses the inferred DCO model and is enabled only in the simulator
+# compile; synthesis sources remain unchanged.
+DCO_SIM_MODEL ?= auto
+DCO_SDF ?= $(ESP_ROOT)/rtl/techmap/asic/dco/DCO_tt.sdf
+DCO_SIM_MODELS := auto behavioral structural
+DCO_BEHAVIORAL_SIM_SRC := $(ESP_ROOT)/rtl/sockets/dvfs/behav_dco.v
+DCO_STRUCTURAL_CORE_SIM_SRCS := \
+	$(ESP_ROOT)/rtl/techmap/asic/dco/DCO_common.v \
+	$(ESP_ROOT)/rtl/techmap/asic/dco/DCO.v
+DCO_STRUCTURAL_SIM_SRCS := \
+	$(ESP_ROOT)/rtl/techmap/asic/dco/DCO_common.v \
+	$(ESP_ROOT)/rtl/techmap/asic/dco/DELAY_CELL.v \
+	$(ESP_ROOT)/rtl/techmap/asic/dco/DCO_LPDDR.v \
+	$(ESP_ROOT)/rtl/techmap/asic/dco/DCO.v
+DCO_EXISTING_STRUCTURAL_SIM_SRCS := $(foreach src,$(DCO_STRUCTURAL_SIM_SRCS),$(if $(wildcard $(src)),$(src)))
+DCO_MISSING_STRUCTURAL_CORE_SIM_SRCS := $(foreach src,$(DCO_STRUCTURAL_CORE_SIM_SRCS),$(if $(wildcard $(src)),,$(src)))
+DCO_MODELSIM_GOALS := sim sim-gui sim-compile modelsim/vsim.mk
+DCO_MODELSIM_REQUESTED := $(filter $(DCO_MODELSIM_GOALS),$(MAKECMDGOALS))
+
+ifeq ($(filter $(DCO_SIM_MODEL),$(DCO_SIM_MODELS)),)
+ifneq ($(DCO_MODELSIM_REQUESTED),)
+$(error Invalid DCO_SIM_MODEL '$(DCO_SIM_MODEL)'; expected one of: $(DCO_SIM_MODELS))
+endif
+endif
+
+ifneq (,$(strip $(OVR_TECHLIB)))
+DCO_SIM_MODEL_RESOLVED := bypass
+else ifeq ($(DCO_SIM_MODEL),auto)
+ifeq (,$(strip $(DCO_MISSING_STRUCTURAL_CORE_SIM_SRCS)))
+ifneq (,$(wildcard $(DCO_SDF)))
+DCO_SIM_MODEL_RESOLVED := structural
+else
+DCO_SIM_MODEL_RESOLVED := behavioral
+endif
+else
+DCO_SIM_MODEL_RESOLVED := behavioral
+endif
+else
+DCO_SIM_MODEL_RESOLVED := $(DCO_SIM_MODEL)
+endif
+
+ifeq ($(DCO_SIM_MODEL_RESOLVED),structural)
+ifneq ($(DCO_MODELSIM_REQUESTED),)
+ifneq (,$(strip $(DCO_MISSING_STRUCTURAL_CORE_SIM_SRCS)))
+$(error Structural DCO simulation is missing core source files: $(DCO_MISSING_STRUCTURAL_CORE_SIM_SRCS))
+endif
+ifeq (,$(wildcard $(DCO_SDF)))
+$(error Structural DCO simulation requires DCO_SDF: $(DCO_SDF))
+endif
+endif
+SIM_VLOG_SRCS := $(filter-out $(DCO_STRUCTURAL_SIM_SRCS),$(SIM_VLOG_SRCS))
+SIM_VLOG_SRCS += $(DCO_EXISTING_STRUCTURAL_SIM_SRCS)
+else ifeq ($(DCO_SIM_MODEL_RESOLVED),behavioral)
+SIM_VLOG_SRCS := $(filter-out $(DCO_STRUCTURAL_SIM_SRCS),$(SIM_VLOG_SRCS))
+SIM_VLOG_SRCS += $(DCO_BEHAVIORAL_SIM_SRC)
+VLOGOPT += +define+ASIC_DCO_BEHAV_FALLBACK
+endif
+
+# A mode change must rebuild the ModelSim work library.  Otherwise a compiled
+# structural DCO can remain in work and shadow the behavioral compatibility
+# wrapper (or vice versa).
+DCO_SIM_MODEL_STAMP := modelsim/.dco_sim_model_$(DCO_SIM_MODEL_RESOLVED)
+$(DCO_SIM_MODEL_STAMP):
+	@mkdir -p modelsim
+	@rm -f modelsim/.dco_sim_model_auto modelsim/.dco_sim_model_behavioral \
+		modelsim/.dco_sim_model_structural modelsim/.dco_sim_model_bypass
+	@touch $@
+
+modelsim/vsim.mk: $(DCO_SIM_MODEL_STAMP)
+
+export DCO_SIM_MODEL_RESOLVED
+export DCO_SDF
+
 ### Uncomment this part when running ASIC flow
 # exist := $(wildcard ../esp_eda/esp/make/asicrun.mk)
 # ifneq ($(strip $(exist)),)

--- a/socs/esp_asic_generic/vsim.tcl
+++ b/socs/esp_asic_generic/vsim.tcl
@@ -1,20 +1,31 @@
-#echo "Restarting simulation with SDF annotation for DCO and delay line"
-set sdf ""
-set TECHLIB $::env(TECHLIB)
-set ESP_ROOT $::env(ESP_ROOT)
+set dco_model $::env(DCO_SIM_MODEL_RESOLVED)
+set dco_sdf $::env(DCO_SDF)
 set VSIMOPT $::env(VSIMOPT)
+set sdf ""
 
-#####################################################################
-# Uncomment this block of code for RTL simulation using DCO clocking#
-#####################################################################
-#foreach inst [find instances -nodu -bydu DCO] {
-#    append sdf "-sdfmax "
-#    append sdf [string map {( [} [string map {) ]} $inst]]
-#    append sdf "=${ESP_ROOT}/rtl/techmap/asic/dco/DCO_tt.sdf "
-#}
-#append sdf "-suppress 3438"
-#####################################################################
-# End block of code                                                 #
-#####################################################################
+puts "DCO simulation model: ${dco_model}"
+
+if {$dco_model eq "structural"} {
+   if {![file readable $dco_sdf]} {
+      error "Structural DCO SDF is not readable: ${dco_sdf}"
+   }
+
+   set dco_instances [find instances -nodu -bydu DCO_ASIC]
+   if {[llength $dco_instances] == 0} {
+      error "Structural DCO simulation found no DCO_ASIC instances to annotate"
+   }
+
+   puts "Annotating [llength $dco_instances] DCO_ASIC instances with ${dco_sdf}"
+   foreach inst $dco_instances {
+      append sdf "-sdfmax "
+      append sdf [string map {( [} [string map {) ]} $inst]]
+      append sdf "=${dco_sdf} "
+   }
+   append sdf "-suppress 3438"
+} elseif {$dco_model eq "behavioral"} {
+   puts "SDF annotation disabled for the functional behavioral DCO"
+} else {
+   puts "ASIC DCO model selection bypassed by the FPGA technology override"
+}
 
 eval vsim $sdf $VSIMOPT


### PR DESCRIPTION
## Summary

Allow ASIC RTL simulation to run without requiring a complete structural DCO and valid timing data.

- Automatically select the structural or behavioral DCO model for ModelSim.
- Use the structural model when the core sources and SDF are available.
- Fall back to the behavioral model when structural data is unavailable.
- Keep synthesis behavior unchanged.

### Changelog

- `rtl/sockets/dvfs/behav_dco.v`
    - Add reset and enable handling.
    - Add external-clock selection.
    - Add programmable clock-divider behavior.
    - Handle unknown DCO configuration values.
    - Add simulation-only `DCO_ASIC` and `DCO_LPDDR` compatibility wrappers.

- `socs/esp_asic_generic/Makefile`
    - Add `auto`, `behavioral`, and `structural` DCO simulation modes.
    - Check for the core structural sources and SDF.
    - Treat LPDDR and delay-line sources as optional.
    - Select the behavioral fallback when structural data is unavailable.
    - Reject incomplete explicitly requested structural simulations.
    - Rebuild the ModelSim work library when the selected model changes.
    - Keep the fallback limited to simulation.

- `socs/esp_asic_generic/vsim.tcl`
    - Read the selected DCO model and SDF path from the environment.
    - Apply SDF annotation to every structural `DCO_ASIC` instance.
    - Validate the SDF and structural DCO instances before simulation.
    - Disable SDF annotation for behavioral simulation.
    - Bypass ASIC DCO selection for FPGA technology overrides.

---

## Motivation

ASIC RTL simulation could either fail during elaboration or hang because the structural DCO was used without compatible structural sources and SDF timing data. This prevented the simulated clocks from providing reliable functional behavior.

The behavioral fallback allows RTL simulation to complete when a valid structural DCO setup is unavailable, while preserving structural simulation for timing-aware verification and leaving synthesis unchanged.

---

## Notes

The DCO model can be selected directly from `make`:
```
make sim DCO_SIM_MODEL=auto
make sim DCO_SIM_MODEL=behavioral
make sim DCO_SIM_MODEL=structural
```

`auto` is the default. It selects the structural model when the required sources and SDF are available, otherwise it uses the behavioral fallback.

A custom SDF can be supplied for structural simulation:
```
make sim DCO_SIM_MODEL=structural DCO_SDF=/path/to/DCO.sdf
```
The same options can be used with `sim-gui` and `sim-compile`.