### PR TITLE
Make ASIC SLM generation architecture-aware and gate Ariane L1 memory

### DIFF
--- a/rtl/techmap/asic/memory_asic.vhd
+++ b/rtl/techmap/asic/memory_asic.vhd
@@ -1100,6 +1100,104 @@ architecture behav of asic_syncram_be is
       );
   end component slm_sram_be_20abits_64dbits;
 
+  component slm_sram_be_14abits_32dbits is
+    port (
+      CLK  : in std_ulogic;
+      CE0  : in std_ulogic;
+      A0   : in std_logic_vector(13 downto 0);
+      D0   : in std_logic_vector(31 downto 0);
+      WE0  : in std_ulogic;
+      WEM0 : in std_logic_vector(31 downto 0);
+      CE1  : in std_ulogic;
+      A1   : in std_logic_vector(13 downto 0);
+      Q1   : out std_logic_vector(31 downto 0)
+      );
+  end component slm_sram_be_14abits_32dbits;
+
+  component slm_sram_be_15abits_32dbits is
+    port (
+      CLK  : in std_ulogic;
+      CE0  : in std_ulogic;
+      A0   : in std_logic_vector(14 downto 0);
+      D0   : in std_logic_vector(31 downto 0);
+      WE0  : in std_ulogic;
+      WEM0 : in std_logic_vector(31 downto 0);
+      CE1  : in std_ulogic;
+      A1   : in std_logic_vector(14 downto 0);
+      Q1   : out std_logic_vector(31 downto 0)
+      );
+  end component slm_sram_be_15abits_32dbits;
+
+  component slm_sram_be_16abits_32dbits is
+    port (
+      CLK  : in std_ulogic;
+      CE0  : in std_ulogic;
+      A0   : in std_logic_vector(15 downto 0);
+      D0   : in std_logic_vector(31 downto 0);
+      WE0  : in std_ulogic;
+      WEM0 : in std_logic_vector(31 downto 0);
+      CE1  : in std_ulogic;
+      A1   : in std_logic_vector(15 downto 0);
+      Q1   : out std_logic_vector(31 downto 0)
+      );
+  end component slm_sram_be_16abits_32dbits;
+
+  component slm_sram_be_17abits_32dbits is
+    port (
+      CLK  : in std_ulogic;
+      CE0  : in std_ulogic;
+      A0   : in std_logic_vector(16 downto 0);
+      D0   : in std_logic_vector(31 downto 0);
+      WE0  : in std_ulogic;
+      WEM0 : in std_logic_vector(31 downto 0);
+      CE1  : in std_ulogic;
+      A1   : in std_logic_vector(16 downto 0);
+      Q1   : out std_logic_vector(31 downto 0)
+      );
+  end component slm_sram_be_17abits_32dbits;
+
+  component slm_sram_be_18abits_32dbits is
+    port (
+      CLK  : in std_ulogic;
+      CE0  : in std_ulogic;
+      A0   : in std_logic_vector(17 downto 0);
+      D0   : in std_logic_vector(31 downto 0);
+      WE0  : in std_ulogic;
+      WEM0 : in std_logic_vector(31 downto 0);
+      CE1  : in std_ulogic;
+      A1   : in std_logic_vector(17 downto 0);
+      Q1   : out std_logic_vector(31 downto 0)
+      );
+  end component slm_sram_be_18abits_32dbits;
+
+  component slm_sram_be_19abits_32dbits is
+    port (
+      CLK  : in std_ulogic;
+      CE0  : in std_ulogic;
+      A0   : in std_logic_vector(18 downto 0);
+      D0   : in std_logic_vector(31 downto 0);
+      WE0  : in std_ulogic;
+      WEM0 : in std_logic_vector(31 downto 0);
+      CE1  : in std_ulogic;
+      A1   : in std_logic_vector(18 downto 0);
+      Q1   : out std_logic_vector(31 downto 0)
+      );
+  end component slm_sram_be_19abits_32dbits;
+
+  component slm_sram_be_20abits_32dbits is
+    port (
+      CLK  : in std_ulogic;
+      CE0  : in std_ulogic;
+      A0   : in std_logic_vector(19 downto 0);
+      D0   : in std_logic_vector(31 downto 0);
+      WE0  : in std_ulogic;
+      WEM0 : in std_logic_vector(31 downto 0);
+      CE1  : in std_ulogic;
+      A1   : in std_logic_vector(19 downto 0);
+      Q1   : out std_logic_vector(31 downto 0)
+      );
+  end component slm_sram_be_20abits_32dbits;
+
 signal gnd : std_ulogic;
 signal do, di : std_logic_vector(dbits+8 downto 0);
 signal xa : std_logic_vector(19 downto 0);
@@ -1128,7 +1226,7 @@ begin
   xrden <= xenable when write  = zeroen else '0';
   xwren <= xenable when write /= zeroen else '0';
 
-  a13 : if abits = 13 generate
+  a13d64 : if abits = 13 and dbits = 64 generate
     r0 : slm_sram_be_13abits_64dbits
       port map (
         CLK  => clk,
@@ -1143,7 +1241,7 @@ begin
     do(dbits+8 downto 8*(((dbits-1)/8)+1)) <= (others => '0');
   end generate;
 
-  a14 : if abits = 14 generate
+  a14d64 : if abits = 14 and dbits = 64 generate
     r0 : slm_sram_be_14abits_64dbits
       port map (
         CLK  => clk,
@@ -1158,7 +1256,7 @@ begin
     do(dbits+8 downto 8*(((dbits-1)/8)+1)) <= (others => '0');
   end generate;
 
-  a15 : if abits = 15 generate
+  a15d64 : if abits = 15 and dbits = 64 generate
     r0 : slm_sram_be_15abits_64dbits
       port map (
         CLK  => clk,
@@ -1173,7 +1271,7 @@ begin
     do(dbits+8 downto 8*(((dbits-1)/8)+1)) <= (others => '0');
   end generate;
 
-  a16 : if abits = 16 generate
+  a16d64 : if abits = 16 and dbits = 64 generate
     r0 : slm_sram_be_16abits_64dbits
       port map (
         CLK  => clk,
@@ -1188,7 +1286,7 @@ begin
     do(dbits+8 downto 8*(((dbits-1)/8)+1)) <= (others => '0');
   end generate;
 
-  a17 : if abits = 17 generate
+  a17d64 : if abits = 17 and dbits = 64 generate
     r0 : slm_sram_be_17abits_64dbits
       port map (
         CLK  => clk,
@@ -1203,7 +1301,7 @@ begin
     do(dbits+8 downto 8*(((dbits-1)/8)+1)) <= (others => '0');
   end generate;
 
-  a18 : if abits = 18 generate
+  a18d64 : if abits = 18 and dbits = 64 generate
     r0 : slm_sram_be_18abits_64dbits
       port map (
         CLK  => clk,
@@ -1218,7 +1316,7 @@ begin
     do(dbits+8 downto 8*(((dbits-1)/8)+1)) <= (others => '0');
   end generate;
 
-  a19 : if abits = 19 generate
+  a19d64 : if abits = 19 and dbits = 64 generate
     r0 : slm_sram_be_19abits_64dbits
       port map (
         CLK  => clk,
@@ -1233,7 +1331,7 @@ begin
     do(dbits+8 downto 8*(((dbits-1)/8)+1)) <= (others => '0');
   end generate;
 
-  a20 : if abits = 20 generate
+  a20d64 : if abits = 20 and dbits = 64 generate
     r0 : slm_sram_be_20abits_64dbits
       port map (
         CLK  => clk,
@@ -1248,12 +1346,119 @@ begin
     do(dbits+8 downto 8*(((dbits-1)/8)+1)) <= (others => '0');
   end generate;
 
+  a14d32 : if abits = 14 and dbits = 32 generate
+    r0 : slm_sram_be_14abits_32dbits
+      port map (
+        CLK  => clk,
+        CE0  => xenable,
+        A0   => xa(13 downto 0),
+        D0   => di(dbits-1 downto 0),
+        WE0  => xwren,
+        WEM0 => xwmsk,
+        CE1  => xrden,
+        A1   => xa(13 downto 0),
+        Q1   => do(dbits-1 downto 0));
+    do(dbits+8 downto 8*(((dbits-1)/8)+1)) <= (others => '0');
+  end generate;
+
+  a15d32 : if abits = 15 and dbits = 32 generate
+    r0 : slm_sram_be_15abits_32dbits
+      port map (
+        CLK  => clk,
+        CE0  => xenable,
+        A0   => xa(14 downto 0),
+        D0   => di(dbits-1 downto 0),
+        WE0  => xwren,
+        WEM0 => xwmsk,
+        CE1  => xrden,
+        A1   => xa(14 downto 0),
+        Q1   => do(dbits-1 downto 0));
+    do(dbits+8 downto 8*(((dbits-1)/8)+1)) <= (others => '0');
+  end generate;
+
+  a16d32 : if abits = 16 and dbits = 32 generate
+    r0 : slm_sram_be_16abits_32dbits
+      port map (
+        CLK  => clk,
+        CE0  => xenable,
+        A0   => xa(15 downto 0),
+        D0   => di(dbits-1 downto 0),
+        WE0  => xwren,
+        WEM0 => xwmsk,
+        CE1  => xrden,
+        A1   => xa(15 downto 0),
+        Q1   => do(dbits-1 downto 0));
+    do(dbits+8 downto 8*(((dbits-1)/8)+1)) <= (others => '0');
+  end generate;
+
+  a17d32 : if abits = 17 and dbits = 32 generate
+    r0 : slm_sram_be_17abits_32dbits
+      port map (
+        CLK  => clk,
+        CE0  => xenable,
+        A0   => xa(16 downto 0),
+        D0   => di(dbits-1 downto 0),
+        WE0  => xwren,
+        WEM0 => xwmsk,
+        CE1  => xrden,
+        A1   => xa(16 downto 0),
+        Q1   => do(dbits-1 downto 0));
+    do(dbits+8 downto 8*(((dbits-1)/8)+1)) <= (others => '0');
+  end generate;
+
+  a18d32 : if abits = 18 and dbits = 32 generate
+    r0 : slm_sram_be_18abits_32dbits
+      port map (
+        CLK  => clk,
+        CE0  => xenable,
+        A0   => xa(17 downto 0),
+        D0   => di(dbits-1 downto 0),
+        WE0  => xwren,
+        WEM0 => xwmsk,
+        CE1  => xrden,
+        A1   => xa(17 downto 0),
+        Q1   => do(dbits-1 downto 0));
+    do(dbits+8 downto 8*(((dbits-1)/8)+1)) <= (others => '0');
+  end generate;
+
+  a19d32 : if abits = 19 and dbits = 32 generate
+    r0 : slm_sram_be_19abits_32dbits
+      port map (
+        CLK  => clk,
+        CE0  => xenable,
+        A0   => xa(18 downto 0),
+        D0   => di(dbits-1 downto 0),
+        WE0  => xwren,
+        WEM0 => xwmsk,
+        CE1  => xrden,
+        A1   => xa(18 downto 0),
+        Q1   => do(dbits-1 downto 0));
+    do(dbits+8 downto 8*(((dbits-1)/8)+1)) <= (others => '0');
+  end generate;
+
+  a20d32 : if abits = 20 and dbits = 32 generate
+    r0 : slm_sram_be_20abits_32dbits
+      port map (
+        CLK  => clk,
+        CE0  => xenable,
+        A0   => xa(19 downto 0),
+        D0   => di(dbits-1 downto 0),
+        WE0  => xwren,
+        WEM0 => xwmsk,
+        CE1  => xrden,
+        A1   => xa(19 downto 0),
+        Q1   => do(dbits-1 downto 0));
+    do(dbits+8 downto 8*(((dbits-1)/8)+1)) <= (others => '0');
+  end generate;
+
   -- pragma translate_off
-  a_to_high : if abits < 13 or abits > 20 or dbits /= 64 generate
+  unsupported_geometry : if not
+    ((dbits = 32 and abits >= 14 and abits <= 20) or
+     (dbits = 64 and abits >= 13 and abits <= 20)) generate
     x : process
     begin
       assert false
-        report  "Data width must be 64 and address width must be between 13 and 20 asic_syncram_be"
+        report  "Unsupported address/data width combination for asic_syncram_be"
         severity failure;
       wait;
     end process;

--- a/tools/asicgen/asic_memgen.py
+++ b/tools/asicgen/asic_memgen.py
@@ -918,13 +918,13 @@ def l1_sp_gen(out_path, mem_dict):
 
 def slm_policy_check(mem_dict):
     valid_word_size = []
-    valid_bits = ["64"]
+    valid_bits = ["32", "64"]
 
     for i in range(len(mem_dict["slm"])):
         if mem_dict["slm"][i]["word_size"] not in valid_bits:
             print("Error: \"slm %s\" " %
                   (' '.join(map(str, list(mem_dict["slm"][i].values())))))
-            print('''       SLM must have word size of 64
+            print('''       SLM must have word size of 32 or 64
                 ''')
         else:
             valid_word_size.append(mem_dict["slm"][i]["word_size"])
@@ -1175,7 +1175,18 @@ def acc_gen(out_path, mem_dict):
         print_lib(file, lib_list, "acc")
 
 
+if len(sys.argv) != 3:
+    print("Usage: asic_memgen.py <output_path> <cpu_arch>")
+    sys.exit(1)
+
 out_path = sys.argv[1]
+cpu_arch = sys.argv[2]
+supported_cpu_archs = ["ariane", "ibex", "leon3"]
+
+if cpu_arch not in supported_cpu_archs:
+    print("Error: unsupported CPU architecture \"%s\"" % cpu_arch)
+    sys.exit(1)
+
 memory_list = []
 with open("asic_memlist.txt", "r") as memories:
     for mem_line in memories:
@@ -1197,7 +1208,11 @@ llc_sp_gen(out_path, mem_dict, val_addr)
 l2_val_addr = l2_policy_check(mem_dict)
 l2_sp_gen(out_path, mem_dict, l2_val_addr)
 
-l1_sp_gen(out_path, mem_dict)
+if cpu_arch == "ariane":
+    if len(mem_dict["l1"]) == 0:
+        print("Error: Ariane requires a 256x64 L1 memory entry in asic_memlist.txt")
+        sys.exit(1)
+    l1_sp_gen(out_path, mem_dict)
 
 slm_val_word = slm_policy_check(mem_dict)
 slm_sp_gen(out_path, mem_dict, slm_val_word)

--- a/tools/socgen/socmap_gen.py
+++ b/tools/socgen/socmap_gen.py
@@ -754,9 +754,21 @@ def print_constants(fp, soc, esp_config):
 
 
 def print_slm(fp, soc, esp_config):
-    abits = int(math.log(esp_config.slm_kbytes, 2) + 8 - soc.ARCH_BITS / 64)
-    fp.write('slm_sram_be_%dabits_64dbits ' %
-             abits + str(2**abits) + ' 64' + ' 1w:0r 0w:1r')
+    dbits = soc.ARCH_BITS
+    if dbits not in (32, 64):
+        raise ValueError("SLM supports only 32-bit and 64-bit architectures")
+
+    total_bits = esp_config.slm_kbytes * 1024 * 8
+    if total_bits % dbits != 0:
+        raise ValueError("SLM capacity must contain an integer number of architecture words")
+
+    words = total_bits // dbits
+    if words <= 0 or (words & (words - 1)) != 0:
+        raise ValueError("SLM word depth must be a positive power of two")
+
+    abits = words.bit_length() - 1
+    fp.write('slm_sram_be_%dabits_%ddbits %d %d 1w:0r 0w:1r' %
+             (abits, dbits, words, dbits))
 
 
 def print_mapping(fp, soc, esp_config):

--- a/utils/make/asicgen.mk
+++ b/utils/make/asicgen.mk
@@ -20,8 +20,8 @@ MEMGEN = $(ESP_ROOT)/tools/asicgen/asic_plmgen.py
 MEMTECH = ../$(DIRTECH_NAME)/mem_wrappers
 MEMGEN_OUT = $(ESP_ROOT)/tech/$(TECHLIB)/memgen/slm_gen
 
-mem_wrapper:
-	$(ASIC_MEMGEN) $(ASIC_MEMGEN_OUT) | tee $(ASIC_MEMGEN_OUT)/asic_memgen.log
+mem_wrapper: $(ESP_CFG_BUILD)/.esp_config
+	$(ASIC_MEMGEN) $(ASIC_MEMGEN_OUT) $(CPU_ARCH) | tee $(ASIC_MEMGEN_OUT)/asic_memgen.log
 
 pad_wrapper:
 	$(ASIC_PADGEN) $(ASIC_PADGEN_OUT) | tee $(ASIC_PADGEN_OUT)/asic_padgen.log


### PR DESCRIPTION
## Summary

- Configure the SLM data width from `ARCH_BITS`, supporting both 32-bit and 64-bit SoCs.
- Preserve the configured SLM capacity by automatically calculating its word depth and address width.
- Extend the ASIC SLM technology mapping with 32-bit memory configurations.
- Generate the CPU L1 SRAM wrapper only for Ariane.
- Pass `CPU_ARCH` automatically from the SoC configuration to the ASIC memory generator.

### Changelog

- `esp/tools/socgen/socmap_gen.py`
    - Derive the SLM data width from `ARCH_BITS`.
    - Calculate the word depth and address width from the configured SLM capacity.
    - Validate supported widths and power-of-two depth.
    - Generate the corresponding 32-bit or 64-bit `slm_memgen.txt` entry.

- `esp/rtl/techmap/asic/memory_asic.vhd`
    - Add 32-bit SLM component declarations and mappings.
    - Support 32-bit SLM address widths from 14 to 20 bits.
    - Preserve the existing 64-bit mappings.
    - Report unsupported address/data-width combinations.

- `esp/tools/asicgen/asic_memgen.py`
    - Accept both 32-bit and 64-bit SLM entries in `asic_memlist.txt`.
    - Generate the L1 wrapper only when Ariane is selected.
    - Report an error when Ariane lacks the required `256x64` L1 entry.
    - Validate the CPU architecture argument.

- esp/utils/make/asicgen.mk
    - Pass `CPU_ARCH` automatically to `asic_memgen.py`.
    - Ensure the generated ESP configuration exists before running `mem_wrapper`.

---

## Notes

- No new command-line input is required. Users continue to run:
```
make mem_wrapper
```
- `CPU_ARCH` is automatically read from `<design-folder>/socgen/esp/.esp_config`.
- Users only need to list their available physical SRAM macros in `asic_memlist.txt`, as before. A 32-bit SLM implementation must include a suitable 32-bit SLM macro entry.
