### PR TITLE
Fix: EDCL UDP reply source port

### DIFF
--- a/rtl/peripherals/ethernet/grethc.vhd
+++ b/rtl/peripherals/ethernet/grethc.vhd
@@ -1666,8 +1666,10 @@ begin
                v.udpsrc := rxo.dataout(15 downto 0);
                v.rcntm := r.rcntm + 2; v.rcntl := r.rcntl + 1; 
              when 5 =>
-               setmz := '1';
-               v.rcntm := r.rcntm + 1; v.rcntl := r.rcntl + 1; 
+               -- Use the request's UDP destination as the reply's UDP source.
+               swap := '1'; veri.writem := '0';
+               veri.waddressl := r.rpnt & (r.rcntl - 1);
+               v.rcntm := r.rcntm + 1; v.rcntl := r.rcntl + 1;
              when 6 =>
                v.rcntm := r.rcntm + 1; v.rcntl := r.rcntl + 1; 
              when 7 =>


### PR DESCRIPTION
## Overview

Fixes a bug in GRETH with UDP reply handling so that the source of a UDP reply now matches the destination of the corresponding UDP request.

## Impact

This bug fix allows EDCL to operate correctly when port forwarded through a router with a different external port to EDCL's expected port. Prior to this fix, whether or not port forwarding EDCL through a router worked was entirely dependent on how that router handled the mismatched UDP reply.